### PR TITLE
Add CSS Modules capability to vue components

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,56 @@ module.exports = {
   ]
 }
 ```
+
+## Local CSS (aka CSS Modules)
+
+To achieve true [CSS Modules](https://github.com/css-modules/css-modules) for each component you can use `vue-loader` in combination with `css-loader` [local-scope](https://github.com/webpack/css-loader#local-scope) and inject a styles object into the `data` object of your components. To get this working you have to set `injectStyle:true` under `vue` like this:  
+
+``` js
+// webpack.config.js
+module.exports = {
+  entry: "./main.js",
+  output: {
+    filename: "build.js"
+  },
+  vue: {
+    injectStyles: true
+  },
+  module: {
+    loaders: [
+      { test: /\.vue$/, loader: "vue-loader" },
+    ]
+  }
+}
+```
+
+In your vue component you can now access styles like:
+
+``` html
+<style>
+:local(.red) {
+  color: red;
+}
+</style>
+
+<template>
+  <span class="{{ styles.red }}">{{msg}}</div>
+</template>
+
+<script>
+module.exports = {
+  data: function () {
+    return {
+      msg: 'Hello World'
+    }
+  }
+}
+</script>
+```
+
+
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -167,10 +167,3 @@ module.exports = {
 }
 </script>
 ```
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -124,30 +124,10 @@ module.exports = {
 
 ## Local CSS (aka CSS Modules)
 
-To achieve true [CSS Modules](https://github.com/css-modules/css-modules) for each component you can use `vue-loader` in combination with `css-loader` [local-scope](https://github.com/webpack/css-loader#local-scope) and inject a styles object into the `data` object of your components. To get this working you have to set `injectStyle:true` under `vue` like this:  
-
-``` js
-// webpack.config.js
-module.exports = {
-  entry: "./main.js",
-  output: {
-    filename: "build.js"
-  },
-  vue: {
-    injectStyles: true
-  },
-  module: {
-    loaders: [
-      { test: /\.vue$/, loader: "vue-loader" },
-    ]
-  }
-}
-```
-
-In your vue component you can now access styles like:
+To achieve true [CSS Modules](https://github.com/css-modules/css-modules) for each component you can use `vue-loader` in combination with `css-loader` [local-scope](https://github.com/webpack/css-loader#local-scope) and inject a styles object into the `data` object of your components. To get this working you need to add the `inject-locals` attribute to the `<style>` tag of your vue component like:
 
 ``` html
-<style>
+<style inject-locals>
 :local(.red) {
   color: red;
 }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,7 +6,6 @@ module.exports = function (content) {
   var languages = {}
   var output = ''
   var vueUrl = loaderUtils.getRemainingRequest(this)
-  var injectStyle = false
 
   // check if there are custom loaders specified with
   // vueLoader.withLoaders(), otherwise use defaults
@@ -14,11 +13,6 @@ module.exports = function (content) {
   loaders.html = loaders.html || 'html'
   loaders.css  = loaders.css || 'style!css'
   loaders.js   = loaders.js || ''
-
-  // Read options from webpack
-  if (this.options.vue !== undefined) {
-    injectStyle = !!this.options.vue.injectStyle
-  }
 
   var loaderPrefix = {
     template: 'html!template-html-loader?raw&engine=',
@@ -87,12 +81,13 @@ module.exports = function (content) {
     }
 
     // add require for styles
-    var hasStyle = false
+    var injectStyleOnce = false
     for (var lang in parts.style) {
       var styles = getRequire('style', lang)
-      if (injectStyle) {
-        if (hasStyle)
-          return cb(new Error('Only one style element allowed per vue component!'))
+      var injectLocals = parts.style[lang].attribs['inject-locals'];
+      if (injectLocals !== undefined) {
+        if (injectStyleOnce)
+          return cb(new Error('Only one style element can be injected per vue component!'))
         // Handle both data function and data object cases.
         output += 'var styles = ' + styles +'\n'
         output += 'if (typeof module.exports.data === "function") {\n'
@@ -105,7 +100,7 @@ module.exports = function (content) {
         output += '} else {\n'
         output += '  module.exports.data.styles = styles\n'
         output += '}\n'
-        hasStyle = true
+        injectStyleOnce = true
       } else {
         output += styles + '\n'
       }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,6 +6,7 @@ module.exports = function (content) {
   var languages = {}
   var output = ''
   var vueUrl = loaderUtils.getRemainingRequest(this)
+  var injectStyle = false
 
   // check if there are custom loaders specified with
   // vueLoader.withLoaders(), otherwise use defaults
@@ -13,6 +14,11 @@ module.exports = function (content) {
   loaders.html = loaders.html || 'html'
   loaders.css  = loaders.css || 'style!css'
   loaders.js   = loaders.js || ''
+
+  // Read options from webpack
+  if (this.options.vue !== undefined) {
+    injectStyle = !!this.options.vue.injectStyle
+  }
 
   var loaderPrefix = {
     template: 'html!template-html-loader?raw&engine=',
@@ -75,14 +81,34 @@ module.exports = function (content) {
       output += 'require(' + loaderUtils.stringifyRequest(this, importReqeust) + ')\n'
     }
 
-    // add require for styles
-    for (var lang in parts.style) {
-      output += getRequire('style', lang) + '\n'
-    }
-
     // add require for script
     for (var lang in parts.script) {
       output += 'module.exports = ' + getRequire('script', lang) + '\n'
+    }
+
+    // add require for styles
+    var hasStyle = false
+    for (var lang in parts.style) {
+      var styles = getRequire('style', lang)
+      if (injectStyle) {
+        if (hasStyle)
+          return cb(new Error('Only one style element allowed per vue component!'))
+        // Handle both data function and data object cases.
+        output += 'var styles = ' + styles +'\n'
+        output += 'if (typeof module.exports.data === "function") {\n'
+        output += '  var cb = module.exports.data\n'
+        output += '  module.exports.data = function() {\n'
+        output += '    var obj = cb()\n'
+        output += '    obj.styles = styles\n'
+        output += '    return obj\n'
+        output += '  }\n'
+        output += '} else {\n'
+        output += '  module.exports.data.styles = styles\n'
+        output += '}\n'
+        hasStyle = true
+      } else {
+        output += styles + '\n'
+      }
     }
 
     // add require for template

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,7 +40,10 @@ module.exports = function (content) {
 
     var start = node.children[0].__location.start
     var end = node.children[node.children.length - 1].__location.end
-    output[type][lang] = content.substring(start, end).trim()
+    output[type][lang] = {
+      attribs: node.attribs,
+      content: content.substring(start, end).trim()
+    }
   })
 
   cb(null, 'module.exports = ' + JSON.stringify(output))

--- a/lib/selector.js
+++ b/lib/selector.js
@@ -10,6 +10,6 @@ module.exports = function () {
     var parts = self.exec(source, url)
     var type = path[0]
     var lang = path[1] || ''
-    cb(null, parts[type][lang])
+    cb(null, parts[type][lang].content)
   })
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "parse5": "^1.1.4"
   },
   "peerDependencies": {
-    "css-loader": "^0.14.4",
+    "css-loader": "^0.15.1",
     "html-loader": "^0.3.0",
     "style-loader": "^0.12.3"
   },
@@ -34,7 +34,7 @@
     "babel-core": "^5.5.8",
     "babel-loader": "^5.1.4",
     "chai": "^3.0.0",
-    "css-loader": "^0.14.4",
+    "css-loader": "^0.15.1",
     "html-loader": "^0.3.0",
     "jade": "^1.11.0",
     "jsdom": "^5.4.3",

--- a/test/fixtures/localcss.js
+++ b/test/fixtures/localcss.js
@@ -1,0 +1,1 @@
+window.testModule = require('./localcss.vue')

--- a/test/fixtures/localcss.vue
+++ b/test/fixtures/localcss.vue
@@ -1,4 +1,4 @@
-<style>
+<style inject-locals>
 :local(.red) {
   color: red;
 }

--- a/test/fixtures/localcss.vue
+++ b/test/fixtures/localcss.vue
@@ -1,0 +1,18 @@
+<style>
+:local(.red) {
+  color: red;
+}
+</style>
+
+<template>
+</template>
+
+<script>
+module.exports = {
+  data: function () {
+    return {
+      msg: 'Hello from Component A!'
+    }
+  }
+}
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -125,7 +125,11 @@ describe('vue-loader', function () {
       }
     }, function (window) {
       var module = window.testModule
-      expect(module.data().styles.red).to.equal('_3iZItEFWW8HWfKNmM95gGD')
+      var data = module.data()
+      expect(data.msg).to.equal('Hello from Component A!')
+      expect(data.styles.red).to.equal('_3iZItEFWW8HWfKNmM95gGD')
+      var style = window.document.querySelector('style').textContent
+      expect(style).to.contain('._3iZItEFWW8HWfKNmM95gGD {\n  color: red;\n}');
       done()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -119,10 +119,7 @@ describe('vue-loader', function () {
 
   it('local-scope', function(done) {
     test({
-      entry: './test/fixtures/localcss.js',
-      vue: {
-        injectStyle: true
-      }
+      entry: './test/fixtures/localcss.js'
     }, function (window) {
       var module = window.testModule
       var data = module.data()

--- a/test/test.js
+++ b/test/test.js
@@ -117,4 +117,17 @@ describe('vue-loader', function () {
     })
   })
 
+  it('local-scope', function(done) {
+    test({
+      entry: './test/fixtures/localcss.js',
+      vue: {
+        injectStyle: true
+      }
+    }, function (window) {
+      var module = window.testModule
+      expect(module.data().styles.red).to.equal('_3iZItEFWW8HWfKNmM95gGD')
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
Like requested in #12 I added support for including css via `css-loader`s [css local scope](https://github.com/webpack/css-loader#local-scope) feature to achieve true CSS Modules like described in [this](https://medium.com/seek-ui-engineering/the-end-of-global-css-90d2a4a06284) blog post.

Technically this is done by injecting the result of the required CSS into the `data` object of each component, to gain access to the exported identifiers in the vue instance.  Makeing this work required that you can't have multiple `<style>`-tags when using this feature. I choose to implement it behind the runtime option `injectStyle`. 

I don't now if injecting it into the Vue component is the most elegant way to do it but it is definitely working. It would be great if it where possible to have a object on the vue instance which will, by default, be a on time binding, without explicitly using `{{* }}` every time. 