### PR TITLE
Preserve line number for linters

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -70,14 +70,36 @@ module.exports = function (content) {
 
     var start = node.childNodes[0].__location.start
     var end = node.childNodes[node.childNodes.length - 1].__location.end
+
+    var result
+    if (type === 'script') {
+      result = commentScript(content.slice(0, start)) +
+              content.slice(start, end) +
+              commentScript(content.slice(end))
+    } else {
+      result = content.slice(start, end).trim()
+    }
+
     output[type].push({
       lang: lang,
       scoped: scoped,
-      content: content.substring(start, end).trim()
+      content: result
     })
   })
 
   cb(null, 'module.exports = ' + JSON.stringify(output))
+}
+
+function commentScript (content) {
+  return content.split(/\n\r|\n|\r/g)
+  .map(function (line) {
+    if (line.trim() === '') {
+      return line
+    } else {
+      return '// ' + line
+    }
+  })
+  .join('\n')
 }
 
 function getAttribute (node, name) {

--- a/test/test.js
+++ b/test/test.js
@@ -141,6 +141,7 @@ describe('vue-loader', function () {
       getFile('test.build.js.map', function (map) {
         var smc = new SourceMapConsumer(JSON.parse(map))
         getFile('test.build.js', function (code) {
+          console.log(code)
           var line
           code.split('\n').some(function (l, i) {
             if (l.indexOf('Hello from Component A') > -1) {
@@ -153,7 +154,7 @@ describe('vue-loader', function () {
             column: 0
           })
           expect(pos.source.indexOf('webpack:///test/fixtures/basic.vue') > -1)
-          expect(pos.line).to.equal(4)
+          expect(pos.line).to.equal(15)
           done()
         })
       })


### PR DESCRIPTION
<img width="871" alt="2015-11-28 2 44 54" src="https://cloud.githubusercontent.com/assets/1676871/11450769/fef7d14a-95de-11e5-8fdc-7a58f2ff6be6.png">

this PR will keep and comment all non-script source code in scripts output,
thus it will preserve line number and be friendly to linters(include file newLine ending).
