### PR TITLE
Resolved issue with CoffeeScript failing to build.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -74,9 +74,9 @@ module.exports = function (content) {
     var result
     if (type === 'script') {
       result =
-        commentScript(content.slice(0, start)) +
-        content.slice(start, end) +
-        commentScript(content.slice(end))
+        // commentScript(content.slice(0, start)) +
+        content.slice(start, end)// +
+        // commentScript(content.slice(end))
     } else {
       result = content.slice(start, end).trim()
     }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -71,7 +71,15 @@ module.exports = function (content) {
     var start = node.childNodes[0].__location.start
     var end = node.childNodes[node.childNodes.length - 1].__location.end
 
-    var result = content.slice(start, end).trim()
+    var result
+    if (type === 'script') {
+      result =
+        commentScript(content.slice(0, start), lang) +
+        content.slice(start, end) +
+        commentScript(content.slice(end), lang)
+    } else {
+      result = content.slice(start, end).trim()
+    }
 
     output[type].push({
       lang: lang,
@@ -83,14 +91,32 @@ module.exports = function (content) {
   cb(null, 'module.exports = ' + JSON.stringify(output))
 }
 
-function commentScript (content) {
+function commentScript (content, lang) {
   return content
     .split(/\n\r|\n|\r/g)
     .map(function (line) {
-      if (line.trim() === '') {
-        return line
-      } else {
-        return '// ' + line
+      switch (lang) {
+        case 'coffee':
+        case 'coffee-jsx':
+        case 'coffee-redux':
+          if (line.trim() === '') {
+            return line
+          } else {
+            return '# ' + line
+          }
+        case 'purs':
+        case 'ulmus':
+          if (line.trim() === '') {
+            return line
+          } else {
+            return '-- ' + line
+          }
+        default:
+          if (line.trim() === '') {
+            return line
+          } else {
+            return '// ' + line
+          }
       }
     })
     .join('\n')

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -71,15 +71,7 @@ module.exports = function (content) {
     var start = node.childNodes[0].__location.start
     var end = node.childNodes[node.childNodes.length - 1].__location.end
 
-    var result
-    if (type === 'script') {
-      result =
-        // commentScript(content.slice(0, start)) +
-        content.slice(start, end)// +
-        // commentScript(content.slice(end))
-    } else {
-      result = content.slice(start, end).trim()
-    }
+    var result = content.slice(start, end).trim()
 
     output[type].push({
       lang: lang,


### PR DESCRIPTION
This PR resolves an issue with CoffeeScript (and CS-like languages) due to the parser adding in `//` comments into the code passed to the respective loader, `coffee-loader` in this case.

Instead of passing commented code, I have modified the code to only pass the code between the `<script>` tags.

I have left the `commentScript` function in case it serves another purpose down the road.

@yyx990803 What was the original purpose for this function? It seems to cause unneeded behavior, since the ES6/Babel parser would ignore the commented lines anyway.