### PR TITLE
Support "src" attribute for script tag

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -153,10 +153,15 @@ module.exports = function (content) {
     })
 
     // add require for script
+    var script
     if (parts.script.length) {
+      script = parts.script[0]
       output +=
-        'module.exports = ' + getRequire('script', parts.script[0], 0) + '\n' +
-        'if (module.exports.__esModule) module.exports = module.exports.default\n'
+        'module.exports = ' + (
+          script.src
+            ? getRequireForImport('script', script, 0)
+            : getRequire('script', script, 0)
+        ) + '\nif (module.exports.__esModule) module.exports = module.exports.default\n'
     }
 
     // add require for template

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -32,11 +32,6 @@ module.exports = function (content) {
 
     // handle src imports
     if (src) {
-      if (type !== 'style' && type !== 'template') {
-        return cb(new Error(
-          '[vue-loader] src import is only supported for <template> and <style> tags.'
-        ))
-      }
       if (type === 'style') {
         output.styleImports.push({
           src: src,
@@ -45,6 +40,11 @@ module.exports = function (content) {
         })
       } else if (type === 'template') {
         output.template.push({
+          src: src,
+          lang: lang
+        })
+      } else if (type === 'script') {
+        output.script.push({
           src: src,
           lang: lang
         })

--- a/test/fixtures/script-import-entry.js
+++ b/test/fixtures/script-import-entry.js
@@ -1,0 +1,1 @@
+window.testModule = require('./script-import.vue')

--- a/test/fixtures/script-import.js
+++ b/test/fixtures/script-import.js
@@ -1,0 +1,7 @@
+export default {
+  data () {
+    return {
+      msg: 'Hello from Component A!'
+    }
+  }
+};

--- a/test/fixtures/script-import.vue
+++ b/test/fixtures/script-import.vue
@@ -1,0 +1,1 @@
+<script src="./script-import.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -130,6 +130,16 @@ describe('vue-loader', function () {
     })
   })
 
+  it('script import', function (done) {
+    test({
+      entry: './test/fixtures/script-import-entry.js'
+    }, function (window) {
+      var module = window.testModule
+      expect(module.data().msg).to.contain('Hello from Component A!')
+      done()
+    })
+  })
+
   it('source map', function (done) {
     var config = Object.assign({}, globalConfig, {
       entry: './test/fixtures/basic.js',


### PR DESCRIPTION
The intention of this PR is to have *.vue files as entry points for components, but the code separated across the js/html/css files and have all the benefits of vue-loader, such as hot-reload