### PR TITLE
Allow postcss options to be a function and close issue #106

### DIFF
--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -36,9 +36,13 @@ module.exports = function (css, map) {
   var query = loaderUtils.parseQuery(this.query)
   var options = this.options.vue || {}
   var autoprefixOptions = options.autoprefixer
+
+  // plugins
   var plugins = options.postcss
-    ? options.postcss.slice() // make sure to copy it
-    : []
+  if (typeof plugins === 'function') {
+    plugins = plugins.call(this, this)
+  }
+  plugins = plugins ? plugins.slice() : [] // make sure to copy it
 
   // scoped css
   if (query.scoped) {

--- a/test/test.js
+++ b/test/test.js
@@ -34,7 +34,7 @@ describe('vue-loader', function () {
 
   function getFile (file, cb) {
     fs.readFile(path.resolve(outputDir, file), 'utf-8', function (err, data) {
-      expect(err).to.be.null
+      expect(err).to.be.not.exist
       cb(data)
     })
   }


### PR DESCRIPTION
1. Allow postcss options to be a function and close issue #106.
2. In node v5.0.0, the error param for `fs.readFile`'s callback is `undefined`, not `null`:)