### PR TITLE
Fixed error when vue module exports a function

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -194,6 +194,7 @@ module.exports = function (content) {
     // attach template
     output +=
       'module.exports = __vue_script__ || {}\n' +
+      'module.exports.options = module.exports.options || {}\n' +
       'if (module.exports.__esModule) module.exports = module.exports.default\n' +
       'if (__vue_template__) { (typeof module.exports === "function" ? module.exports.options : module.exports).template = __vue_template__ }\n'
     // hot reload


### PR DESCRIPTION
This code would rise an error:
```vue
<script>
module.exports = function (context) {
}
</script>
```

The deal is that `module.options` is not defined in this case, and there's `module.options.template` usage in vue-loader.