### PR TITLE
move `defaultLoaders` to module.exports

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -11,12 +11,6 @@ var defaultLang = {
   script: 'js'
 }
 
-var defaultLoaders = {
-  html: 'vue-html-loader',
-  css: 'vue-style-loader!css-loader',
-  js: 'babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false'
-}
-
 var rewriterInjectRE = /\b((css|(vue-)?html)(-loader)?(\?[^!]+)?!?)\b/
 var rewriters = {
   template: require.resolve('./template-rewriter'),
@@ -24,6 +18,13 @@ var rewriters = {
 }
 
 module.exports = function (content) {
+
+  var defaultLoaders = {
+    html: 'vue-html-loader',
+    css: 'vue-style-loader!css-loader',
+    js: 'babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false'
+  }
+  
   this.cacheable()
   var loaderContext = this
   var options = this.options.vue || {}

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -24,7 +24,7 @@ module.exports = function (content) {
     css: 'vue-style-loader!css-loader',
     js: 'babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false'
   }
-  
+
   this.cacheable()
   var loaderContext = this
   var options = this.options.vue || {}


### PR DESCRIPTION
 move `defaultLoaders` to module.exports to prevent that in mutiple webpack build situations, previous `defaultLoaders` configuration will be cached and apply to following builds, which would ignore following `webpack.vue` options such as `cssSourceMap: false`