### PR TITLE
Skip rewriter injection when loader has absolute path

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -96,9 +96,18 @@ module.exports = function (content) {
       // inject rewriter before css/html loader for
       // extractTextPlugin use cases
       if (rewriterInjectRE.test(loader)) {
-        loader = loader.replace(rewriterInjectRE, function (m, $1) {
-          return ensureBang($1) + rewriter
-        })
+        loader = loader.split('!').map(function (part) {
+          // if loader referenced with absoulte path and contains `html` or `css` words
+          // than rewriteInjectRE will not work as expected
+          if (part.indexOf(path.sep) !== -1) {
+            return part
+          }
+
+          // FIXIT: better regular expression, which skips absolute paths with `html` or `css` words?
+          return part.replace(rewriterInjectRE, function (m, $1) {
+            return ensureBang($1) + rewriter
+          })
+        }).join('!')
       } else {
         loader = ensureBang(loader) + rewriter
       }


### PR DESCRIPTION
rewriterInjectRE matches single `html` and `css` words, so if loader is referenced via absolute path (extractTextPlugin case) and that path contains `html` or `css` words than rewriter will be injected right after them. This should not happen.

Fixes #204 