### PR TITLE
Enable passing options to the template engine

### DIFF
--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -6,6 +6,12 @@ module.exports = function (content) {
   this.cacheable && this.cacheable()
   var callback = this.async()
   var opt = loaderUtils.parseQuery(this.query)
+  var vue = this.options.vue
+  if (vue && vue.template) {
+    for (var key in vue.template) {
+      opt[key] = vue.template[key]
+    }
+  }
 
   function exportContent (content) {
     if (opt.raw) {


### PR DESCRIPTION
Merges `vue.template` with the HTML preprocessor query string.