### PR TITLE
pass query.id as an option to addId in style-rewriter

### DIFF
--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -3,8 +3,7 @@ var selectorParser = require('postcss-selector-parser')
 var loaderUtils = require('loader-utils')
 var assign = require('object-assign')
 
-var currentId
-var addId = postcss.plugin('add-id', function () {
+var addId = postcss.plugin('add-id', function (opts) {
   return function (root) {
     root.each(function rewriteSelector (node) {
       if (!node.selector) {
@@ -21,7 +20,7 @@ var addId = postcss.plugin('add-id', function () {
             if (n.type !== 'pseudo') node = n
           })
           selector.insertAfter(node, selectorParser.attribute({
-            attribute: currentId
+            attribute: opts.id
           }))
         })
       }).process(node.selector).result
@@ -46,7 +45,7 @@ module.exports = function (css, map) {
 
   // scoped css
   if (query.scoped) {
-    plugins.push(addId)
+    plugins.push(addId({ id: query.id }))
   }
 
   // autoprefixer
@@ -82,7 +81,6 @@ module.exports = function (css, map) {
     }
   }
 
-  currentId = query.id
   postcss(plugins)
     .process(css, opts)
     .then(function (result) {


### PR DESCRIPTION
Global variables (`currentId`) should not be used for passing arguments to "execute-later" async functions.

This patch fixes a hard-to-reproduce bug, which is described below.

For example, I have two vue component `foo.vue` and `bar.vue` and they both have the same content as below:
```html
<template>
  <div class="hello"></div>
</template>
<style scoped>
  .hello { display: none; }
</style>
```
When I use them like this:
```html
<foo></foo>
<bar></bar>
```
It produces HTML as following
```html
<div class="hello" _v-1234567></div>
<div class="hello" _v-2222222></div>
```
This is correct. But on the style side, you get the following with some setup
```css
.hello[_v-2222222] { display: none; }    /* from foo.vue, the id should be _v-1234567 */
.hello[_v-2222222] { display: none; }    /* from bar.vue, correct */
```
and the following with some other setup
```css
.hello[] { display: none; }    /* from foo.vue, there should be id in brackets */
.hello[] { display: none; }    /* from bar.vue, there should be id in brackets */
```
The expected style is
```css
.hello[_v-1234567] { display: none; }    /* from foo.vue */
.hello[_v-2222222] { display: none; }    /* from bar.vue */
```

You won't reproduce the bug by replaying what I said above. It's only a simplified description of what I've observed from our quite big codebase with complex dependencies. But you can reason about it.