### PR TITLE
Allow vue-loader to user PostCSS options as object and custom syntax

### DIFF
--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -40,8 +40,7 @@ module.exports = function (css, map) {
   var plugins = options.postcss
   if (typeof plugins === 'function') {
     plugins = plugins.call(this, this)
-  }
-  else if (typeof plugins === 'object') {
+  } else if (typeof plugins === 'object') {
     plugins = options.postcss.plugins
   }
   plugins = plugins ? plugins.slice() : [] // make sure to copy it

--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -40,7 +40,7 @@ module.exports = function (css, map) {
   var plugins = options.postcss
   if (typeof plugins === 'function') {
     plugins = plugins.call(this, this)
-  } else if (typeof plugins === 'object') {
+  } else if (typeof options.postcss === 'object' && options.postcss.plugins) {
     plugins = options.postcss.plugins
   }
   plugins = plugins ? plugins.slice() : [] // make sure to copy it
@@ -84,7 +84,7 @@ module.exports = function (css, map) {
   }
 
   // postcss options, for syntax
-  if (options.postcss.syntax) {
+  if (options.postcss && options.postcss.syntax) {
     opts.parser = options.postcss.syntax
   }
 

--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -41,6 +41,9 @@ module.exports = function (css, map) {
   if (typeof plugins === 'function') {
     plugins = plugins.call(this, this)
   }
+  else if (typeof plugins === 'object') {
+    plugins = options.postcss.plugins
+  }
   plugins = plugins ? plugins.slice() : [] // make sure to copy it
 
   // scoped css
@@ -79,6 +82,11 @@ module.exports = function (css, map) {
       annotation: false,
       prev: map
     }
+  }
+
+  // postcss options, for syntax
+  if (options.postcss.syntax) {
+    opts.parser = options.postcss.syntax
   }
 
   postcss(plugins)

--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -86,7 +86,7 @@ module.exports = function (css, map) {
 
   // postcss options from configuration
   if (options.postcss && options.postcss.options) {
-    for (option in options.postcss.options) {
+    for (var option in options.postcss.options) {
       if (!opts.hasOwnProperty(option)) {
         opts[option] = options.postcss.options[option]
       }

--- a/lib/style-rewriter.js
+++ b/lib/style-rewriter.js
@@ -74,7 +74,8 @@ module.exports = function (css, map) {
     this.sourceMap &&
     !this.minimize &&
     options.cssSourceMap !== false &&
-    process.env.NODE_ENV !== 'production'
+    process.env.NODE_ENV !== 'production' &&
+    !options.postcss.options.map
   ) {
     opts.map = {
       inline: false,
@@ -83,9 +84,13 @@ module.exports = function (css, map) {
     }
   }
 
-  // postcss options, for syntax
-  if (options.postcss && options.postcss.syntax) {
-    opts.parser = options.postcss.syntax
+  // postcss options from configuration
+  if (options.postcss && options.postcss.options) {
+    for (option in options.postcss.options) {
+      if (!opts.hasOwnProperty(option)) {
+        opts[option] = options.postcss.options[option]
+      }
+    }
   }
 
   postcss(plugins)


### PR DESCRIPTION
I wanted to use SugarSS with PostCSS with vue-loader. It wasn't possible without modifying the style-rewriter and changing the way options works.

You still can use the 
`postcss: array of plugins`
`postcss: function that return array of plugins`

or the new one
```
postcss: {
  plugins: array of plugins,
  syntax: custom syntax, like sugarss
}
```

Allowing the use of sugarss or others syntax as custom postcss syntax with vue loader.