### PR TITLE
Use loaderUtils.stringifyRequest for relative path

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -220,7 +220,7 @@ module.exports = function (content) {
         '  var hotAPI = require("vue-hot-reload-api")\n' +
         '  hotAPI.install(require("vue"), false)\n' +
         '  if (!hotAPI.compatible) return\n' +
-        '  var id = ' + JSON.stringify(filePath) + '\n' +
+        '  var id = ' + loaderUtils.stringifyRequest(loaderContext, filePath) + '\n' +
         '  if (!module.hot.data) {\n' +
         // initial insert
         '    hotAPI.createRecord(id, module.exports)\n' +


### PR DESCRIPTION
I'm new to all this, but any reason we're not using [stringifyRequest](https://github.com/webpack/loader-utils#stringifyrequest) from `loader-utils`? The current approach results in machine-specific absolute paths in the generated bundle.

https://webpack.github.io/docs/how-to-write-a-loader.html#should-not-embed-absolute-paths