### PR TITLE
removed peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,17 +42,6 @@
     "source-map": "^0.5.3",
     "vue-template-validator": "^1.0.0"
   },
-  "peerDependencies": {
-    "babel-loader": "^6.2.4",
-    "babel-core": "^6.8.0",
-    "babel-plugin-transform-runtime": "^6.8.0",
-    "babel-runtime": "^6.0.0",
-    "babel-preset-es2015": "^6.6.0",
-    "css-loader": "*",
-    "vue-html-loader": "^1.0.0",
-    "vue-style-loader": "^1.0.0",
-    "vue-hot-reload-api": "^1.2.0"
-  },
   "devDependencies": {
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
to allow error free npm install when not using style / hot-reload or babel
#241

https://github.com/vuejs/vueify/issues/81
