### PR TITLE
Add support for options.query of babel-loader

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -46,10 +46,20 @@ module.exports = function (content) {
     process.env.NODE_ENV !== 'production' &&
     options.cssSourceMap !== false
 
+  var babelQuery = ''
+  if (hasBabel) {
+    var globalLoaders = this.options.module.loaders
+    for (var i = globalLoaders.length - 1; i >= 0; i--) {
+      if (globalLoaders[i].loader === 'babel') {
+        babelQuery = globalLoaders[i].query ? '?' + JSON.stringify(globalLoaders[i].query) : ''
+      }
+    }
+  }
+
   var defaultLoaders = {
     html: templateCompilerPath + '?id=' + moduleId,
     css: styleLoaderPath + '!css-loader' + (needCssSourceMap ? '?sourceMap' : ''),
-    js: hasBabel ? 'babel-loader' : ''
+    js: hasBabel ? 'babel-loader' + babelQuery : ''
   }
 
   // check if there are custom loaders specified via

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-exponentiation-operator": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "chai": "^3.0.0",
     "coffee-loader": "^0.7.2",

--- a/test/fixtures/babel.vue
+++ b/test/fixtures/babel.vue
@@ -1,0 +1,13 @@
+<template>
+  <span>{{ squared }}</span>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      squared: 2 ** 2
+    }
+  }
+}
+</script>

--- a/test/fixtures/basic.vue
+++ b/test/fixtures/basic.vue
@@ -1,5 +1,5 @@
 <template>
-  <h2 class="red">{{msg}}</h2>
+  <h2 class="red">{{ msg }}</h2>
 </template>
 
 <script>

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,63 @@ describe('vue-loader', function () {
     })
   })
 
+  it('babel loader', function (done) {
+    var counter = 0
+    var n = 2
+
+    bundle(Object.assign({}, globalConfig, {
+      entry: './test/fixtures/babel.vue',
+      module: {
+        loaders: [
+          {
+            test: /\.vue$/,
+            loader: loaderPath
+          },
+          {
+            test: /\.js?/,
+            loader: 'babel',
+            exclude: /node_modules/,
+            query: {
+              plugins: ['transform-exponentiation-operator']
+            }
+          }
+        ]
+      }
+    }), function (code) {
+      expect(code).to.not.contain('2 ** 2')
+      expect(code).to.contain('Math.pow(2, 2)')
+      if (++counter === n) {
+        done()
+      }
+    })
+
+    bundle(Object.assign({}, globalConfig, {
+      entry: './test/fixtures/babel.vue',
+      module: {
+        loaders: [
+          {
+            test: /\.vue$/,
+            loader: loaderPath
+          },
+          {
+            test: /\.js?/,
+            loader: 'babel',
+            exclude: /node_modules/
+          }
+        ]
+      },
+      babel: {
+        plugins: ['transform-exponentiation-operator']
+      }
+    }), function (code) {
+      expect(code).to.not.contain('2 ** 2')
+      expect(code).to.contain('Math.pow(2, 2)')
+      if (++counter === n) {
+        done()
+      }
+    })
+  })
+
   it('pre-processors', function (done) {
     test({
       entry: './test/fixtures/pre.vue'


### PR DESCRIPTION
It seems like that if you add `!!` before `babel-loader`, the options(including query) of `babel-loader` will be ignored by webpack, but the `babel:` option and `.babelrc` still works.
This PR just makes the `options.query` of `babel-loader` work.
