### PR TITLE
Handle partial tag (fix #134)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -7,6 +7,7 @@ var path = require('path')
 
 var defaultLang = {
   template: 'html',
+  partial: 'html',
   style: 'css',
   script: 'js'
 }
@@ -106,6 +107,7 @@ module.exports = function (content) {
       // unknown lang, infer the loader to be used
       switch (type) {
         case 'template':
+        case 'partial':
           return defaultLoaders.html + '!' + rewriter + templateLoader + '?raw&engine=' + lang + '!'
         case 'style':
           return defaultLoaders.css + '!' + rewriter + lang + '!'
@@ -119,6 +121,7 @@ module.exports = function (content) {
     var meta = '?id=' + moduleId
     switch (type) {
       case 'template':
+      case 'partial':
         return scoped ? (rewriters.template + meta + '!') : ''
       case 'style':
         return rewriters.style + (scoped ? meta + '&scoped=true!' : '!')
@@ -143,7 +146,7 @@ module.exports = function (content) {
 
   var parts = parse(content, fileName, this.sourceMap)
   var hasLocalStyles = false
-  var output = 'var __vue_script__, __vue_template__\n'
+  var output = 'var __vue_script__, __vue_template__, __vue_partials__\n'
 
   // check if there are any template syntax errors
   var templateWarnings = parts.template.length && parts.template[0].warnings
@@ -198,6 +201,19 @@ module.exports = function (content) {
       )
   }
 
+  // add require for partials
+  if (parts.partial.length) {
+    output += '__vue_partials__ = {\n'
+    parts.partial.forEach(function (partial, index) {
+      output += `'${partial.name}':`
+      output += partial.src
+        ? getRequireForImport('partial', partial, hasLocalStyles)
+        : getRequire('partial', partial, index, hasLocalStyles)
+      output += ',\n'
+    })
+    output += '}\n'
+  }
+
   if (!query.inject) {
     // attach template
     output +=
@@ -207,6 +223,11 @@ module.exports = function (content) {
         '(typeof module.exports === "function" ' +
           '? (module.exports.options || (module.exports.options = {})) ' +
           ': module.exports).template = __vue_template__\n' +
+      '}\n' +
+      'if (__vue_partials__) {\n' +
+        '(typeof module.exports === "function" ' +
+          '? (module.exports.options || (module.exports.options = {})) ' +
+          ': module.exports).partials = __vue_partials__\n' +
       '}\n'
     // hot reload
     if (
@@ -239,6 +260,7 @@ module.exports = function (content) {
       '    : {}\n' +
       '  if (mod.__esModule) mod = mod.default\n' +
       '  if (__vue_template__) { (typeof mod === "function" ? mod.options : mod).template = __vue_template__ }\n' +
+      '  if (__vue_partials__) { (typeof mod === "function" ? mod.options : mod).partials = __vue_partials__ }\n' +
       '  return mod\n' +
       '}'
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -28,7 +28,8 @@ module.exports = function (content, filename, needMap) {
     template: [],
     style: [],
     script: [],
-    styleImports: []
+    styleImports: [],
+    partial: []
   }
 
   var fragment = parse5.parseFragment(content, {
@@ -40,6 +41,7 @@ module.exports = function (content, filename, needMap) {
     var lang = getAttribute(node, 'lang')
     var src = getAttribute(node, 'src')
     var scoped = getAttribute(node, 'scoped') != null
+    var name = getAttribute(node, 'name')
     var warnings = null
     var map = null
 
@@ -76,12 +78,18 @@ module.exports = function (content, filename, needMap) {
           src: src,
           lang: lang
         })
+      } else if (type === 'partial') {
+        output.partial.push({
+          name: name,
+          src: src,
+          lang: lang
+        })
       }
       return
     }
 
     // skip empty script/style tags
-    if (type !== 'template' && (!node.childNodes || !node.childNodes.length)) {
+    if (type !== 'template' && type !== 'partial' && (!node.childNodes || !node.childNodes.length)) {
       return
     }
 
@@ -91,6 +99,8 @@ module.exports = function (content, filename, needMap) {
       if (!lang) {
         warnings = validateTemplate(node, content)
       }
+    } else if (type === 'partial' && !lang) {
+      warnings = validateTemplate(node, content)
     }
 
     // extract part
@@ -152,6 +162,7 @@ module.exports = function (content, filename, needMap) {
       lang: lang,
       scoped: scoped,
       content: result,
+      name: name,
       map: map && map.toJSON(),
       warnings: warnings
     })

--- a/test/fixtures/partials.vue
+++ b/test/fixtures/partials.vue
@@ -1,0 +1,9 @@
+<partial name="hello-partial">
+  <div>Hello</div>
+</partial>
+
+<partial name="bye-partial">
+  <div>Bye</div>
+</partial>
+
+<partial name="jade-partial" lang="jade" src="./template-import.jade"></partial>

--- a/test/test.js
+++ b/test/test.js
@@ -276,4 +276,16 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('partials', function (done) {
+    test({
+      entry: './test/fixtures/partials.vue'
+    }, function (window) {
+      var module = window.vueModule
+      expect(module.partials).to.have.property('hello-partial').that.contain('<div>Hello</div>')
+      expect(module.partials).to.have.property('bye-partial').that.contain('<div>Bye</div>')
+      expect(module.partials).to.have.property('jade-partial').that.contain('<div><h1>hello</h1></div>')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This PR allow to define partials with a `<partial>` tag as propposed in #134 allowing to write:
```xml
<template>
  <div>
    <partial name="my-partial"></partial>
  </div>
</template>

<partial name="my-partial">
  <div>Hello</div>
</partial>
```

The partials are injected into the `partials` option under the `name` key (ie. `my-partial` in the previous example)

Follow the same rule as `<template>` tag:
- template syntax specified with `lang` attribute
- can be loaded from another file with  `src` attribute