### PR TITLE
`eslint-html-plugin` to `eslint-plugin-html`

### DIFF
--- a/docs/en/workflow/linting.md
+++ b/docs/en/workflow/linting.md
@@ -2,7 +2,7 @@
 
 You may have been wondering how do you lint your code inside `*.vue` files, since they are not JavaScript. We will assume you are using [ESLint](http://eslint.org/) (if you are not, you should!).
 
-You will also need the [eslint-html-plugin](https://github.com/BenoitZugmeyer/eslint-plugin-html) with supports extracting and linting the JavaScript inside `*.vue` files.
+You will also need the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) with supports extracting and linting the JavaScript inside `*.vue` files.
 
 Make sure to include the plugin in your ESLint config:
 


### PR DESCRIPTION
I saw the text is `eslint-html-plugin` while that package names `eslint-plugin-html`.

Maybe a typo?