### PR TITLE
Support LiveScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ There are also some example projects:
 
 - [vue-loader-example](https://github.com/vuejs/vue-loader-example/)
 - [vue-hackernews](https://github.com/vuejs/vue-hackernews)
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -31,7 +31,7 @@ But Webpack can do more than that. With "loaders", we can teach Webpack to trans
 - Transpile ES2015, CoffeeScript or TypeScript modules into plain ES5 CommonJS modules;
 - Optionally you can pipe the source code through a linter before doing the compilation;
 - Transpile Jade templates into plain HTML and inline it as a JavaScript string;
-- Transpile SASS files into plain CSS, then convert it into a JavaScript snippet that insert the resulting CSS as a `<style>` tag;
+- Transpile SASS files into plain CSS, then convert it into a JavaScript snippet that inserts the resulting CSS as a `<style>` tag;
 - Process an image file referenced in HTML or CSS, moved it to the desired destination based on the path configurations, and naming it using its md5 hash.
 
 Webpack is so powerful that when you understand how it works, it can dramatically improve your front-end workflow. Its primary drawback is verbose and complex configuration; but with this guide you should be able to find solutions for most common issues when using Webpack with Vue.js and `vue-loader`.

--- a/docs/en/features/postcss.md
+++ b/docs/en/features/postcss.md
@@ -32,7 +32,7 @@ module.exports = {
 
 ### Using Custom PostCSS Plugins
 
-To use custom PostCSS pugins, pass an array to the `postcss` option under the `vue` section. Example using [CSSNext](http://cssnext.io/):
+To use custom PostCSS plugins, pass an array to the `postcss` option under the `vue` section. Example using [CSSNext](http://cssnext.io/):
 
 ``` js
 // webpack.config.js

--- a/docs/en/start/tutorial.md
+++ b/docs/en/start/tutorial.md
@@ -37,7 +37,7 @@ npm install\
 npm install vue --save
 ```
 
-That's a lot of dependencies, I know! This is mostly because `vue-loader` need to have other webpack loaders as **peer dependencies** rather than nested dependencies so that Webpack can find them.[^(1)]
+That's a lot of dependencies, I know! This is mostly because `vue-loader` needs to have other webpack loaders as **peer dependencies** rather than nested dependencies so that Webpack can find them.[^(1)]
 
 > Note: In previous versions of `vue-loader` we used to explicitly install `babel-runtime` 5.x to avoid duplicate dependencies - this is no longer necessary after recent babel upgrade.
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -214,13 +214,14 @@ module.exports = function (content) {
       process.env.NODE_ENV !== 'production' &&
       (parts.script.length || parts.template.length)
     ) {
+      var hotId = JSON.stringify(moduleId + '/' + fileName)
       output +=
         'if (module.hot) {(function () {' +
         '  module.hot.accept()\n' +
         '  var hotAPI = require("vue-hot-reload-api")\n' +
         '  hotAPI.install(require("vue"), false)\n' +
         '  if (!hotAPI.compatible) return\n' +
-        '  var id = ' + loaderUtils.stringifyRequest(loaderContext, filePath) + '\n' +
+        '  var id = ' + hotId + '\n' +
         '  if (!module.hot.data) {\n' +
         // initial insert
         '    hotAPI.createRecord(id, module.exports)\n' +

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -13,6 +13,7 @@ var commentSymbols = {
   'coffee': '#',
   'coffee-jsx': '#',
   'coffee-redux': '#',
+  'livescript': '#',
   'purs': '--',
   'ulmus': '--'
 }

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -27,10 +27,10 @@ module.exports = function (content) {
   }
 
   if (!cons[opt.engine]) {
-    throw new Error(
+    return callback(new Error(
       'Template engine \'' + opt.engine + '\' ' +
       'isn\'t available in Consolidate.js'
-    )
+    ))
   }
 
   // for relative includes
@@ -38,8 +38,9 @@ module.exports = function (content) {
 
   cons[opt.engine].render(content, opt, function (err, html) {
     if (err) {
-      throw err
+      callback(err)
+    } else {
+      exportContent(html)
     }
-    exportContent(html)
   })
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-loader",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "description": "Vue.js component loader for Webpack",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
LiveScript used "#" as inline comment symbol.

Fix: https://github.com/vuejs/vue-loader/issues/135
