### PR TITLE
Add ability to set `transformToRequire` option under `vue` in webpack…

### DIFF
--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -8,7 +8,7 @@ var hotReloadAPIPath = normalize.dep('vue-hot-reload-api')
 var defaultTransformToRequire = {
   img: 'src'
 }
-var transformToRequire = Object.assign({}, defaultTransformToRequire);
+var transformToRequire = Object.assign({}, defaultTransformToRequire)
 var options = {
   modules: [{
     postTransformNode (el) {

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -16,10 +16,10 @@ var options = {
         if (el.tag === tag && el.attrs) {
           var attributes = transformToRequire[tag]
           if (typeof attributes === 'string') {
-            el.attrs.some(attr => rewrite(attr, attributes)) 
+            el.attrs.some(attr => rewrite(attr, attributes))
           } else if (Array.isArray(attributes)) {
             attributes.forEach(item => el.attrs.some(attr => rewrite(attr, item)))
-          } 
+          }
         }
       }
     }

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -4,19 +4,25 @@ var beautify = require('js-beautify').js_beautify
 var normalize = require('./normalize')
 var hotReloadAPIPath = normalize.dep('vue-hot-reload-api')
 
-// vue compiler module for using file-loader img src
+// vue compiler module for using transforming `<tag>:<attribute>` to `require`
+var defaultTransformToRequire = {
+  img: 'src'
+}
+var transformToRequire = Object.assign({}, defaultTransformToRequire);
 var options = {
   modules: [{
     postTransformNode (el) {
-      if (el.tag === 'img') {
-        el.attrs && el.attrs.some(rewrite)
+      for (var key in transformToRequire) {
+        if (el.tag === key) {
+          el.attrs && el.attrs.some(attr => rewrite(attr, transformToRequire[key]))
+        }
       }
     }
   }]
 }
 
-function rewrite (attr) {
-  if (attr.name === 'src') {
+function rewrite (attr, name) {
+  if (attr.name === name) {
     var value = attr.value
     var isStatic = value.charAt(0) === '"' && value.charAt(value.length - 1) === '"'
     if (!isStatic) {
@@ -37,6 +43,9 @@ module.exports = function (html) {
   this.cacheable()
   var query = loaderUtils.parseQuery(this.query)
   var isServer = this.options.target === 'node'
+  if (this.options.vue && this.options.vue.transformToRequire) {
+    Object.assign(transformToRequire, this.options.vue.transformToRequire)
+  }
   var compiled = compiler.compile(html, options)
   var code
   if (compiled.errors.length) {

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -12,9 +12,14 @@ var transformToRequire = Object.assign({}, defaultTransformToRequire)
 var options = {
   modules: [{
     postTransformNode (el) {
-      for (var key in transformToRequire) {
-        if (el.tag === key) {
-          el.attrs && el.attrs.some(attr => rewrite(attr, transformToRequire[key]))
+      for (var tag in transformToRequire) {
+        if (el.tag === tag && el.attrs) {
+          var attributes = transformToRequire[tag]
+          if (typeof attributes === 'string') {
+            el.attrs.some(attr => rewrite(attr, attributes)) 
+          } else if (Array.isArray(attributes)) {
+            attributes.forEach(item => el.attrs.some(attr => rewrite(attr, item)))
+          } 
         }
       }
     }


### PR DESCRIPTION
Add ability to set `transformToRequire` option under `vue` in webpack config,
This provides the missing feature from [html-loader](https://github.com/webpack/html-loader) to specify which tag-attribute combination to be transformed to `require()`.

`transformToRequire` Defaults to {img: 'src'}.

Example usage: (in webpack.config.js)
```javascript
vue: {
  transformToRequire: {
    foo: 'bar'
  }
}
```
will transform `<foo bar="..."/>` to `<foo bar="require(...)"/>`