### PR TITLE
allow to export constructor even if using es6 default export

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -170,7 +170,10 @@ module.exports = function (content) {
   var exports =
     '__vue_options__ = __vue_exports__ = __vue_exports__ || {}\n' +
     // ES6 modules interop
-    'if (typeof __vue_exports__.default === "object") {\n' +
+    'if (\n' +
+    '  typeof __vue_exports__.default === "object" ||\n' +
+    '  typeof __vue_exports__.default === "function"\n' +
+    ') {\n' +
       (isProduction ? '' : checkNamedExports) +
       '__vue_options__ = __vue_exports__ = __vue_exports__.default\n' +
     '}\n' +

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.0.0",
     "sugarss": "^0.1.3",
+    "vue": "^2.0.0-rc.4",
     "webpack": "^1.12.2"
   }
 }

--- a/test/fixtures/extend.vue
+++ b/test/fixtures/extend.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>{{ msg }}</div>
+</template>
+
+<script>
+import Vue from 'vue'
+export default Vue.extend({
+  data () {
+    return { msg: 'success' }
+  }
+})
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -333,4 +333,18 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('allows to export extended constructor', function (done) {
+    test({
+      entry: './test/fixtures/extend.vue'
+    }, function (window, module) {
+      // should export Vue constructor
+      var vnode = mockRender(module.options, {
+        msg: 'success'
+      })
+      expect(vnode.tag).to.equal('div')
+      expect(vnode.children[0]).to.equal('success')
+      done()
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -337,13 +337,14 @@ describe('vue-loader', function () {
   it('allows to export extended constructor', function (done) {
     test({
       entry: './test/fixtures/extend.vue'
-    }, function (window, module) {
-      // should export Vue constructor
-      var vnode = mockRender(module.options, {
+    }, function (window, Module) {
+      // extend.vue should export Vue constructor
+      var vnode = mockRender(Module.options, {
         msg: 'success'
       })
       expect(vnode.tag).to.equal('div')
       expect(vnode.children[0]).to.equal('success')
+      expect(new Module().msg === 'success')
       done()
     })
   })


### PR DESCRIPTION
This patch fixes #340.

We are checking `typeof __vue_exports__.default` for ES6 modules interop but only checking whether it is an object or not.
If we export Vue constructor (`export default Vue.extend({...})`), the check is failed and it exports incorrect object.
I have add `typeof __vue_exports__.default === 'function'` to handle such situation.