### PR TITLE
template opt prop - fixes #342

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ There are also some example projects:
 
 - [vue-loader-example](https://github.com/vuejs/vue-loader-example/)
 - [vue-hackernews](https://github.com/vuejs/vue-hackernews)
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -31,7 +31,7 @@ But Webpack can do more than that. With "loaders", we can teach Webpack to trans
 - Transpile ES2015, CoffeeScript or TypeScript modules into plain ES5 CommonJS modules;
 - Optionally you can pipe the source code through a linter before doing the compilation;
 - Transpile Jade templates into plain HTML and inline it as a JavaScript string;
-- Transpile SASS files into plain CSS, then convert it into a JavaScript snippet that insert the resulting CSS as a `<style>` tag;
+- Transpile SASS files into plain CSS, then convert it into a JavaScript snippet that inserts the resulting CSS as a `<style>` tag;
 - Process an image file referenced in HTML or CSS, moved it to the desired destination based on the path configurations, and naming it using its md5 hash.
 
 Webpack is so powerful that when you understand how it works, it can dramatically improve your front-end workflow. Its primary drawback is verbose and complex configuration; but with this guide you should be able to find solutions for most common issues when using Webpack with Vue.js and `vue-loader`.

--- a/docs/en/features/postcss.md
+++ b/docs/en/features/postcss.md
@@ -32,7 +32,7 @@ module.exports = {
 
 ### Using Custom PostCSS Plugins
 
-To use custom PostCSS pugins, pass an array to the `postcss` option under the `vue` section. Example using [CSSNext](http://cssnext.io/):
+To use custom PostCSS plugins, pass an array to the `postcss` option under the `vue` section. Example using [CSSNext](http://cssnext.io/):
 
 ``` js
 // webpack.config.js

--- a/docs/en/start/tutorial.md
+++ b/docs/en/start/tutorial.md
@@ -37,7 +37,7 @@ npm install\
 npm install vue --save
 ```
 
-That's a lot of dependencies, I know! This is mostly because `vue-loader` need to have other webpack loaders as **peer dependencies** rather than nested dependencies so that Webpack can find them.[^(1)]
+That's a lot of dependencies, I know! This is mostly because `vue-loader` needs to have other webpack loaders as **peer dependencies** rather than nested dependencies so that Webpack can find them.[^(1)]
 
 > Note: In previous versions of `vue-loader` we used to explicitly install `babel-runtime` 5.x to avoid duplicate dependencies - this is no longer necessary after recent babel upgrade.
 

--- a/docs/en/start/tutorial.md
+++ b/docs/en/start/tutorial.md
@@ -46,28 +46,28 @@ After proper installation, your `package.json`'s `devDependencies` field should 
 ``` json
 ...
   "devDependencies": {
-    "babel-core": "^6.3.17",
-    "babel-loader": "^6.2.0",
-    "babel-plugin-transform-runtime": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-runtime": "^5.8.34",
-    "css-loader": "^0.23.0",
-    "vue-hot-reload-api": "^1.2.2",
-    "vue-html-loader": "^1.0.0",
+    "babel-core": "^6.13.2",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-runtime": "^6.12.0",
+    "babel-preset-es2015": "^6.13.2",
+    "babel-runtime": "^5.8.38",
+    "css-loader": "^0.23.1",
+    "vue-hot-reload-api": "^1.3.3",
+    "vue-html-loader": "^1.2.3",
+    "vue-loader": "^7.5.3",
     "vue-style-loader": "^1.0.0",
-    "vue-loader": "^7.2.0",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "webpack": "^1.13.1",
+    "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "vue": "^1.0.13"
-  },
+    "vue": "^1.0.26"
+  }
 ...
 ```
 
 ### Configuring Webpack
 
-Here's the most basic Webpack configuration for `vue-loader`:
+Here's a basic Webpack configuration for `vue-loader`:
 
 ``` js
 // webpack.config.js
@@ -86,8 +86,19 @@ module.exports = {
       {
         test: /\.vue$/, // a regex for matching all files that end in `.vue`
         loader: 'vue'   // loader to use for matched files
-      }
+      },
+      {
+        // use babel-loader for *.js files
+        test: /\.js$/,
+        loader: 'babel',
+        // important: exclude files in node_modules
+        // otherwise it's going to be really slow!
+        exclude: /node_modules/
+      }      
     ]
+  },
+  babel: {
+    presets: ['es2015']
   }
 }
 ```
@@ -108,7 +119,7 @@ The app entry point, `main.js` typically looks like this (using ES2015 syntax):
 // main.js
 import Vue from 'vue'
 // require a *.vue component
-import App from './components/App'
+import App from './components/App.vue'
 
 // mount a root Vue instance
 new Vue({
@@ -144,14 +155,37 @@ export default {
 </script>
 ```
 
+Now create a couple of basic sub-components.
+
+`./components/ComponentA.vue`
+``` html
+<template>
+  <div>Component A</div>
+</template>
+```
+
+`./components/ComponentB.vue`
+``` html
+<template>
+  <div>Component B</div>
+</template>
+```
+
 Next, let's create an `index.html` that simply uses the bundled file:
 
 ``` html
 <!-- index.html -->
-<body>
-  <app></app>
-  <script src="build.js"></script>
-</body>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Vue.js Tutorial</title>
+  </head>
+  <body>
+    <app></app>
+    <script src="build.js"></script>
+  </body>
+</html>
 ```
 
 ### Running It

--- a/docs/en/workflow/linting.md
+++ b/docs/en/workflow/linting.md
@@ -2,7 +2,7 @@
 
 You may have been wondering how do you lint your code inside `*.vue` files, since they are not JavaScript. We will assume you are using [ESLint](http://eslint.org/) (if you are not, you should!).
 
-You will also need the [eslint-html-plugin](https://github.com/BenoitZugmeyer/eslint-plugin-html) with supports extracting and linting the JavaScript inside `*.vue` files.
+You will also need the [eslint-plugin-html](https://github.com/BenoitZugmeyer/eslint-plugin-html) with supports extracting and linting the JavaScript inside `*.vue` files.
 
 Make sure to include the plugin in your ESLint config:
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -1,0 +1,37 @@
+# 介绍
+
+### `vue-loader` 是什么？
+
+`vue-loader` 是 webpack 的一个 loader，能把像下图格式那样的 Vue 组件转化成纯 JavaScript 模块：
+
+![screenshot](http://blog.evanyou.me/images/vue-component.png)
+
+`vue-loader` 提供了很多不错的功能:
+
+- 默认支持 ES2015；
+- 支持对 Vue 组件的各部分使用其他 Webpack loader，例如 针对 `<style>` 使用Sass，针对 `<template>` 使用 Jade；
+- 把 `<style>` 和 `<template>` 中引用的静态资源当做一个模块依赖，并使用 Webpack loader 处理；
+- 可以给每个组件“模拟”出 CSS 作用域；
+- 在开发阶段，支持组件热加载。
+
+简而言之，Webpack 结合 `vue-loader` 提供一个现代的、灵活的和极其给力的前端工作流，帮助你开发 Vue.js 应用。
+
+### Webpack 是什么？
+
+如果你很熟悉 Webpack 大可跳过下面的解释，对于 Webpack 新手，以下是简要说明：
+
+[Webpack](http://webpack.github.io/) 是一个模块化管理打包工具，它找到一堆文件，然后把每个文件当做一个模块，找出它们之间的依赖，打包生成用于开发的静态资源。
+
+![webpack](http://webpack.github.io/assets/what-is-webpack.png)
+
+举个简单例子，想象一下我们有很多 CommonJS 风格的模块，这些模块是没法在浏览器里直接跑的，所以我们要把它们“打包”到一个文件里，于是，就可以通过 `<script>` 标签来引用这个文件。Webpack 能够借着 `require()` 的调用找到所有的依赖，然后打包出一个我们要的 JavaScript 文件。
+
+Webpack 还能做很多别的。借助 "loader"，我们可以告诉 Webpack 如何处理各种类型的文件，让它按照我们期望的转换方式输出到最终的打包文件里。举些例子：
+
+- 转换 ES2015、CoffeeScript 或 TypeScript 代码为原生 ES5 CommonJS 模块；
+- 可选择在编译处理前，把源代码连接（pipe）到一个代码检测器；
+- 转换 Jade 模板为原生 HTML 然后把它当作 JavaScript 字符串在代码中使用；
+- 转换 SASS 文件为原生 CSS, 然后生成一段 JavaScript 代码，这段代码会把转换得到的 CSS 用 `<style>` 标签插入到页面；
+- 处理 HTML 或 CSS 引用的图片，根据路径配置把它移动到想要的位置，并使用 md5 命名；
+
+如果你理解 Webpack 是如何工作的，你会感叹它如此给力，它极大地促进前端工作流。它主要缺点就是配置繁琐复杂，不过有了这份文档之后，当你结合 webpack 使用 Vue.js 和 `vue-loader` 时，它能帮你解决大多数常见问题。

--- a/docs/zh-cn/SUMMARY.md
+++ b/docs/zh-cn/SUMMARY.md
@@ -1,0 +1,19 @@
+- 入门
+  - [Vue 组件说明](start/spec.md)
+  - [基础指南](start/tutorial.md)
+- 功能
+  - [ES2015 和 Babel](features/es2015.md)
+  - [CSS 作用域](features/scoped-css.md)
+  - [PostCSS 和 Autoprefixer](features/postcss.md)
+  - [热加载](features/hot-reload.md)
+- 配置
+  - [预处理器](configurations/pre-processors.md)
+  - [处理资源 URL](configurations/asset-url.md)
+  - [高级 Loader 配置](configurations/advanced.md)
+  - [提取 CSS 文件](configurations/extract-css.md)
+- 工作流
+  - [构建用于生产环境](workflow/production.md)
+  - [检查代码](workflow/linting.md)
+  - [测试](workflow/testing.md)
+  - [用 Mocks 测试](workflow/testing-with-mocks.md)
+- [配置项说明](options.md)

--- a/docs/zh-cn/configurations/advanced.md
+++ b/docs/zh-cn/configurations/advanced.md
@@ -1,0 +1,33 @@
+# 高级 Loader 配置
+
+有时候，你想要给某种语言指定一个 loader 字符串，而不是让 `vue-loader` 去探测得到，或者只是想覆盖默认语言内置的 loader 配置。想要实现这些，只要在 Webpack 配置中增加一块 `vue` 配置，然后设置 `loaders` 选项。
+
+例子：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // other options...
+  module: {
+    loaders: [
+      {
+        test: /\.vue$/,
+        loader: 'vue'
+      }
+    ]
+  },
+  // vue-loader configurations
+  vue: {
+    // ... other vue options
+    loaders: {
+      // 使用 coffee-loader 处理所有 <script>，无须指定 "lang" 属性
+      js: 'coffee',
+      // 直接加载 <template> 作为 HTML字符串
+      // 无须先连接（pipe）到 vue-html-loader
+      html: 'raw'
+    }
+  }
+}
+```
+
+一个更实用的高级 loader 配置就是 [把组件内的 CSS 抽取成单独的文件](./extract-css.md)。

--- a/docs/zh-cn/configurations/asset-url.md
+++ b/docs/zh-cn/configurations/asset-url.md
@@ -1,0 +1,37 @@
+# 处理资源 URL
+
+默认情况下，`vue-loader` 使用 [css-loader](https://github.com/webpack/css-loader) 和 [vue-html-loader](https://github.com/vuejs/vue-html-loader) （只是 Vue 风格的 [html-loader](https://github.com/webpack/html-loader)） 自动处理你的样式和模板。这意味着，所有的资源 URL，例如 `<img src="...">`、`background: url(...)` 和 CSS `@import` 都会被 **转化处理成模块依赖**。
+
+例如，`url(image.png)` 将会被转化为 `require('./image.png')`，因为 `.png` 不是 JavaScript，所以你需要告诉 Webpack 使用 [file-loader](https://github.com/webpack/file-loader) 和 [url-loader](https://github.com/webpack/url-loader) 来处理他们。这做法看上去有点累赘，不过也给你带来极大的好处，就是可以管理静态资源了：
+
+1. `file-loader` 允许你指定文件从哪里来和到哪里去，以及使用哈希命名来作版本控制。最给力的是，你在源码里面可以基于文件结构使用相对路径，然后 Webpack 会根据你给出的配置，自动把它们重写成你要的路径，然后输出到打包文件里。（译者：碉堡了，为什么那么多人还用~~~）
+
+2. `url-loader` 允许你给定一个阈值，当 url 引用的文件大小小于这个值时，则把文件内容转化为内联的 base64 data URL，这能减少小文件的 HTTP 请求数。如果文件大小超过这个阈值，则自动回退使用 `file-loader` 处理。
+
+这里有一个例子，展示 Webpack 配置文件如何处理 `.png`, `jpg` 和 `.gif` 文件，并且把文件大小小于 10kb 的作为 base64 data URL：
+
+``` bash
+npm install url-loader file-loader --save-dev
+```
+
+``` js
+// webpack.config.js
+module.exports = {
+  // ... other options
+  module: {
+    loaders: [
+      // ... other loaders
+      {
+        test: /\.(png|jpg|gif)$/,
+        loader: 'url',
+        query: {
+          // 低于该值则内联为 base64，单位是 byte
+          limit: 10000,
+          // 对于超过阈值的文件，定义命名规则
+          name: '[name].[ext]?[hash]'
+        }
+      }
+    ]
+  }
+}
+```

--- a/docs/zh-cn/configurations/extract-css.md
+++ b/docs/zh-cn/configurations/extract-css.md
@@ -1,0 +1,34 @@
+# 提取 CSS 为单独文件
+
+配置例子，展示如何提取所有组件处理后的 CSS，然后放到一个单独的 CSS 文件里：
+
+``` bash
+npm install extract-text-webpack-plugin --save-dev
+```
+
+``` js
+// webpack.config.js
+var ExtractTextPlugin = require("extract-text-webpack-plugin");
+
+module.exports = {
+  // other options...
+  module: {
+    loaders: [
+      {
+        test: /\.vue$/,
+        loader: 'vue'
+      },
+    ]
+  },
+  vue: {
+    loaders: {
+      css: ExtractTextPlugin.extract("css"),
+      // 你还可以用 <style lang="less"> 或其他语言
+      less: ExtractTextPlugin.extract("css!less")
+    }
+  },
+  plugins: [
+    new ExtractTextPlugin("style.css")
+  ]
+}
+```

--- a/docs/zh-cn/configurations/pre-processors.md
+++ b/docs/zh-cn/configurations/pre-processors.md
@@ -1,0 +1,62 @@
+# 使用预处理器
+
+在 Webpack 中，所有的预处理器需要通过相应的 loader 来应用。`vue-loader` 允许你使用其他 Webpack loader 来处理 Vue 组件的各部分，它会自动从语言块的 `lang` 属性中探测出合适的 loader。
+
+### CSS
+
+例如，我们想用 SASS 来编译 `<style>` 标签：
+
+``` bash
+npm install sass-loader node-sass --save-dev
+```
+
+``` html
+<style lang="sass">
+  /* write sass here */
+</style>
+```
+
+通过这样声明，`<style>` 标签下的内容会首先通过 `sass-loader` 编译，然后再将结果传给后面的处理器。
+
+### JavaScript
+
+Vue 组件里的所有 JavaScript 默认使用 `babel-loader` 处理，当然你是可以换成别的：
+
+``` bash
+npm install coffee-loader --save-dev
+```
+
+``` html
+<script lang="coffee">
+  # Write coffeescript!
+</script>
+```
+
+### Templates
+
+处理模板的方式有一点点不一样，因为大多数 Webpack 模板 loader，如 `jade-loader` 会返回一个方法，而不是一个编译后的 HTML 字符串。于是我们安装原始的 `jade` 来代替 `jade-loader` ：
+
+``` bash
+npm install jade --save-dev
+```
+
+``` html
+<template lang="jade">
+div
+  h1 Hello world!
+</template>
+```
+
+> **关键:** 如果你的 `vue-loader` 版本 `<8.2.0`，你还得安装 `template-html-loader` 才行。
+
+### 内联 Loader 请求
+
+你可以使用在 `lang` 属性使用 [Webpack loader requests](https://webpack.github.io/docs/loaders.html#introduction)。
+
+``` html
+<style lang="sass?outputStyle=expanded">
+  /* use sass here with expanded output */
+</style>
+```
+
+不过要注意，这样用的话，Vue 组件就只能在 Webpack 下用，而不能兼容 Browserify 和 [vueify](https://github.com/vuejs/vueify)。**如果你的 Vue 组件要作为第三方组件被复用的话，避免使用这种语法。**

--- a/docs/zh-cn/features/es2015.md
+++ b/docs/zh-cn/features/es2015.md
@@ -1,0 +1,93 @@
+# 配置 ES2015 和 Babel
+
+`vue-loader` 附带 ES2015（也叫 ES6），在 `<script>` 中默认支持。Vue 组件的所有脚本代码都使用 `babel-loader`，通过 [Babel](https://babeljs.io/) 来完成编译。如果你还没用上新的语言特性，你真的得用用了。有一些不错的学习资源：
+
+- [Babel - Learn ES2015](https://babeljs.io/docs/learn-es2015/)
+- [ES6 Features](https://github.com/lukehoban/es6features)
+- [Exploring ES6 (book)](https://leanpub.com/exploring-es6)
+
+以下是一种导入其他 Vue 组件的经典地方式：
+
+``` html
+<script>
+import ComponentA from './ComponentA.vue'
+import ComponentB from './ComponentB.vue'
+
+export default {
+  components: {
+    ComponentA,
+    ComponentB
+  }
+}
+</script>
+```
+
+我们用 ES2015 字面量对象的简写语法来定义子组件。其中 `{ ComponentA }` 代表 `{ ComponentA: ComponentA }` ，Vue 会自动的将键名转化为 `component-a`，所以你可以在模板中写 `<component-a>` 来使用导入的组件。
+
+
+### 自定义配置 Babel
+
+> **注意兼容性**: `vue-loader` 7.0+ 使用 Babel 6。如果你需要使用 Babel 5 来转换代码的话，请用 vue-loader 6.x 版本。
+
+Vue 组件的代码使用 Babel 的默认配置为：
+
+``` json
+{
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime"]
+}
+```
+
+如果你想自己配置别的 presets 或 plugins，例如想要使用 stage-0 的语言特性，则安装相应 preset 或 plugin，然后在 Webpack 配置中增加 `babel` 字段：
+
+``` bash
+npm install babel-preset-stage-0 --save-dev
+```
+
+``` js
+// webpack.config.js
+module.exports = {
+  // other configs...
+  babel: {
+    // enable stage 0 babel transforms.
+    presets: ['es2015', 'stage-0'],
+    plugins: ['transform-runtime']
+  }
+}
+```
+
+另一种方式就是，在项目根目录增加一个 `.babelrc` 配置文件。（译者：内容就是 babel 字段对应的 json 对象）
+
+### 通过 Babel 编译 `.js` 文件
+
+反正都已经用上 Babel 了，你大概也想编译其它普通 `.js` 文件。下面告诉你如何通过配置 Webpack 实现：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // other options ...
+  module: {
+    loaders: [
+      {
+        // use vue-loader for *.vue files
+        test: /\.vue$/,
+        loader: 'vue'
+      },
+      {
+        // 对所有 *.js 文件使用 babel-loader
+        test: /\.js$/,
+        loader: 'babel',
+        // 重点: 排除 node_modules 中的文件，
+        // 不然真的会非常慢！
+        exclude: /node_modules/
+      }
+    ]
+  },
+  // 如果你自己直接用上 babel-loader，
+  // 那么 babel 配置项就是必须配的。
+  babel: {
+    presets: ['es2015'],
+    plugins: ['transform-runtime']
+  }
+}
+```

--- a/docs/zh-cn/features/hot-reload.md
+++ b/docs/zh-cn/features/hot-reload.md
@@ -1,0 +1,42 @@
+﻿# 热加载
+
+"热加载" 不只是简单的重新加载修改后的文件。有了热加载之后，当你修改一个 `*.vue` 文件后，这个组件对应的所有实例都会换成新的，而且 **无须重新加载页面**，甚至还保持整个应用以及这些刷新组件的当前状态。
+
+![hot-reload](http://blog.evanyou.me/images/vue-hot.gif)
+
+### 开启热加载
+
+要开启热加载，最简单的方式就是 [基础指南](../start/tutorial.md) 中稍微提到的：
+
+``` js
+// package.json
+...
+"scripts": {
+  "dev": "webpack-dev-server --inline --hot"
+}
+...
+```
+
+这里假设访问项目根目录和访问其下的 `index.html` 是一样的。默认情况下，Webpack dev server 会使用当前工作目录作为内容的基目录，然后提供目录中所有静态文件的访问。
+
+运行 `npm run dev` 然后通过 `http://localhost:8080` 访问静态应用。
+
+### 热加载注意事项
+
+- 当一个组件可以热加载时，它当前的状态是会保持的，不过组件本身是会销毁并重新创建的，所以，它的生命周期钩子方法都会相应被调用。要确保恰当地解除生命周期方法中产生的副作用。
+
+- 对于热加载组件的子组件，无法保证在热加载后，它的私有状态与之前是一致的。
+
+- Vue 根实例，或手动挂载的实例，无法进行热加载，而是要强制整个重新加载。
+
+### 配置提示
+
+- 你可以使用 `--port` 项来指定服务器使用别的端口
+
+- 如果你的文件结构不一样，你需要在 Webpack 配置文件中配置 `output.publicPath`，相应地，在 webpack-dev-server 命令中设置 `--content-base`。
+
+- 如果你使用 HTML5 history API（例如你用了 `vue-router`），那么也要增加 `--history-api-fallback`。
+
+- 查看 [Webpack dev server 文档](https://webpack.github.io/docs/webpack-dev-server.html) 了解其他高级用法，例如结合其他后台服务器使用 webpack dev server。
+
+- 最后，如果你有一个基于 Node.js 后台的 [Express](http://expressjs.com/en/index.html) 项目，你只需增加 [Webpack dev 中间件](https://webpack.github.io/docs/webpack-dev-middleware.html) 来返回 webpack 相关访问。

--- a/docs/zh-cn/features/postcss.md
+++ b/docs/zh-cn/features/postcss.md
@@ -1,0 +1,64 @@
+# PostCSS 和 Autoprefixer
+
+所有经过 `vue-loader` 处理输出的 CSS 都会连接（pipe）到 [PostCSS](https://github.com/postcss/postcss) 进行作用域 CSS 重写，然后使用 [autoprefixer](https://github.com/postcss/autoprefixer) 自动添加前缀。
+
+### 配置 Autoprefixer
+
+你可以使用 webpack 配置中 `vue` 下的 `autoprefixer` 配置项来配置 autoprefixer。参考 [autoprefixer 的可配置项](https://github.com/postcss/autoprefixer#options)。当然，你可以设置 `false` 来禁用 autoprefixing。
+
+例子：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // 其他配置项...
+  module: {
+    loaders: [
+      {
+        test: /\.vue$/,
+        loader: 'vue'
+      }
+    ]
+  },
+  // vue-loader 配置
+  vue: {
+    // 配置 autoprefixer
+    autoprefixer: {
+      browsers: ['last 2 versions']
+    }
+  }
+}
+```
+
+### 自定义 PostCSS 插件
+
+要自定义使用 PostCSS 的插件，可以在 `vue` 下的 `postcss` 配置项传入一个数组。下面是使用 [CSSNext](http://cssnext.io/) 插件的例子：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // other configs...
+  vue: {
+    // 自定义使用 postcss 插件
+    postcss: [require('postcss-cssnext')()],
+    // 禁用 vue-loader 的 autoprefixing.
+    // 因为 cssnext 包含这个功能，所以禁用它准没错
+    autoprefixer: false
+  }
+}
+```
+
+`postcss` 配置项除了可以配置数组以外，还支持：
+
+- 一个方法，其中返回插件数组
+
+- 一个对象，包含传递给 PostCSS 处理器的配置项。如果你使用 PostCSS 时依赖了自定义的 解析器/生成器，这种配置就很好用。
+
+  ``` js
+  postcss: {
+    plugins: [...], // 插件列表
+    options: {
+      parser: sugarss // 使用 sugarss 解析器
+    }
+  }
+  ```

--- a/docs/zh-cn/features/scoped-css.md
+++ b/docs/zh-cn/features/scoped-css.md
@@ -1,0 +1,51 @@
+# 带作用域的 CSS
+
+当一个 `<style>` 标签有了 `作用域` 属性，它的 CSS 将仅仅作用于当前组件的元素，这跟 Shadow Dom 的样式封装很像。它会引起一些警告，但不需要任何 polyfill。这个功能借助 PostCSS 实现，它会将下面代码：
+
+``` html
+<style scoped>
+.example {
+  color: red;
+}
+</style>
+
+<template>
+  <div class="example">hi</div>
+</template>
+```
+
+转化为这样的代码：
+
+``` html
+<style>
+.example[_v-f3f3eg9] {
+  color: red;
+}
+</style>
+
+<template>
+  <div class="example" _v-f3f3eg9>hi</div>
+</template>
+```
+
+#### 注意
+
+1. 在同一个组件中，你可以同时使用带作用域和不带的：
+
+  ``` html
+  <style>
+  /* global styles */
+  </style>
+
+  <style scoped>
+  /* local styles */
+  </style>
+  ```
+
+2. 一个子组件的根节点会同时受到父组件的 CSS 作用域，以及子组件自身 CSS 作用域的影响。
+
+3. Partials 不受样式作用域影响。
+
+4. **作用域样式不排除使用类选择器**. 根据浏览器渲染不同选择器样式的方式， `p { color: red }` 加上作用域（如，与属性选择器结合）后会慢了几倍。如果你用类或者 ID 选择器代替，如 `.example { color: red }`，基本没有性能问题。[这里有一个测试环境](http://stevesouders.com/efws/css-selectors/csscreate.php)，你可以测试不同选择器的差异。
+
+5. **“多代”组件，慎用后代选择器！** 有一个样式规则使用 `.a .b` 选择器，此时，若匹配 `.a` 的元素包含“多代”子组件的话，则匹配 `.b` 的各代子组件都会应用该样式。

--- a/docs/zh-cn/getting-started.md
+++ b/docs/zh-cn/getting-started.md
@@ -1,0 +1,176 @@
+# Getting Started
+
+### Syntax Highlighting
+
+First thing first, you will probably want proper syntax highlighting for `*.vue` components. Currently there are syntax highlighting support for [Sublime Text](https://github.com/vuejs/vue-syntax-highlight), [Atom](https://atom.io/packages/language-vue) and [Vim](https://github.com/posva/vim-vue). Contributions for other editors/IDEs are highly appreciated! If you are not using any pre-processors in Vue components, you can also get by by treating `*.vue` files as HTML in your editor.
+
+### Project Structure
+
+We are going to walk through setting up a Webpack + `vue-loader` project from scratch. If you are interested in ready-to-run examples, check out [vue-loader-example](https://github.com/vuejs/vue-loader-example) and [vue-hackernews](https://github.com/vuejs/vue-hackernews). However, if you are not already a Webpack expert, I highly recommend going through the following tutorial to understand how the pieces fit together.
+
+A simple `vue-loader` based project structure looks like this:
+
+``` bash
+.
+├── index.html
+├── main.js
+├── components
+│   ├── App.vue
+│   ├── ComponentA.vue
+│   └── ComponentB.vue
+├── package.json
+└── webpack.config.js
+```
+
+### Installing Dependencies
+
+Before we write any code, we need to install the proper NPM dependencies. Let's run:
+
+``` bash
+# Create a package.json file.
+# fill in the questions as you desire.
+npm init
+
+# Install everything we need
+npm install\
+  webpack webpack-dev-server\
+  vue-loader vue-html-loader css-loader style-loader vue-hot-reload-api\
+  babel-loader babel-core babel-plugin-transform-runtime babel-preset-es2015\
+  babel-runtime@5\
+  --save-dev
+```
+
+That's a lot of dependencies, I know! This is mostly because `vue-loader` need to have other webpack loaders as **peer dependencies** rather than nested dependencies so that Webpack can find them.[^(1)]
+
+You may also notice that we are using `babel-runtime` version 5 instead of the latest 6.x - this is [intentional](https://github.com/vuejs/vue-loader/issues/96#issuecomment-162910917).
+
+After proper installation, your `package.json`'s `devDependencies` field should look like this:
+
+``` json
+...
+  "devDependencies": {
+    "babel-core": "^6.3.17",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-runtime": "^5.8.34",
+    "css-loader": "^0.23.0",
+    "style-loader": "^0.13.0",
+    "vue-hot-reload-api": "^1.2.2",
+    "vue-html-loader": "^1.0.0",
+    "vue-loader": "^7.2.0",
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
+  },
+...
+```
+
+### Configuring Webpack
+
+Here's the most basic Webpack configuration for `vue-loader`:
+
+``` js
+// webpack.config.js
+module.exports = {
+  // entry point of our application
+  entry: './main.js',
+  // where to place the compiled bundle
+  output: {
+    path: __dirname,
+    filename: 'build.js'
+  },
+  module: {
+    // `loaders` is an array of loaders to use.
+    // here we are only configuring vue-loader
+    loaders: [
+      {
+        test: /\.vue$/, // a regex for matching all files that end in `.vue`
+        loader: 'vue'   // loader to use for matched files
+      }
+    ]
+  }
+}
+```
+
+With the above configuration, when you write the following in your JavaScript code:
+
+``` js
+var MyComponent = require('./my-component.vue')
+```
+
+Webpack knows it needs to pipe the contents of `./my-component.vue` through `vue-loader`, because the filename matches the regex we provided in the config.
+
+### Creating Other Files
+
+The app entry point, `main.js` typically looks like this:
+
+``` js
+// main.js
+var Vue = require('vue')
+// require a *.vue component
+var App = require('./components/App.vue')
+
+// mount a root Vue instance
+new Vue({
+  el: 'body',
+  components: {
+    // include the required component
+    // in the options
+    app: App
+  }
+})
+```
+
+Inside a `*.vue` component's `<script>` tag, you can also require other `*.vue` components. For example in `./components/App.vue` (we will talk about ES2015 later):
+
+``` html
+<template>
+  <div class="app">
+    <component-a></component-a>
+    <component-b></component-b>
+  </div>
+</template>
+
+<script>
+module.exports = {
+  components: {
+    'component-a': require('./ComponentA.vue'),
+    'component-b': require('./ComponentB.vue')
+  }
+}
+</script>
+```
+
+Next, let's create an `index.html` that simply uses the bundled file:
+
+``` html
+<!-- index.html -->
+<body>
+  <app></app>
+  <script src="build.js"></script>
+</body>
+```
+
+### Running It
+
+Finally, it's time to get it running! We will simply use [NPM scripts](https://docs.npmjs.com/misc/scripts) as our task runner, which is sufficient in most cases. Add the following to your `package.json`:
+
+``` json
+...
+"scripts": {
+  "dev": "webpack-dev-server --inline --hot"
+}
+...
+```
+
+Then run:
+
+``` bash
+npm run dev
+```
+
+And you should see your app working at `http://localhost:8080`, with hot-reloading enabled!
+
+---
+
+[^(1)] If you are using NPM version 2.x, when you do `npm install vue-loader --save-dev` it will install and save all the peer dependencies for you. However, if you are using NPM 3.x, these peer dependencies will no longer be automatically installed. You will have to install them explicitly like we did above. Another way to deal with it is to simply copy `vue-loader`'s peer dependencies into your `package.json`'s `devDependencies` field and then run `npm install`.

--- a/docs/zh-cn/options.md
+++ b/docs/zh-cn/options.md
@@ -1,0 +1,75 @@
+﻿# 配置项说明
+
+### loaders
+
+- 类型: `Object`
+
+一个对象。如果 `*.vue` 文件的语言块声明了 `lang` 属性，则该对象指明对应使用哪个 Webpack loader 处理。
+
+  - `<template>`: `html`
+  - `<script>`: `js`
+  - `<style>`: `css`
+
+  例如，使用 `babel-loader` 和 `eslint-loader` 处理所有 `<script>` 块：
+
+  ``` js
+  // ...
+  vue: {
+    loaders: {
+      js: 'babel!eslint'
+    }
+  }
+  ```
+
+### autoprefixer
+
+- 类型: `Boolean`
+- 默认: `true`
+
+  是否对 `*.vue` 文件中的 CSS 进行 autoprefixer
+
+### postcss
+
+- 类型: `Array` or `Function` or `Object`
+- ^8.5.0 版本仅支持 `Object`
+
+  自定义指定 PostCSS 插件，应用到 `*.vue` 文件中的 CSS。如果配置一个方法，则该方法会使用同样的 loader 上下文，然后需要返回一个插件数组。
+
+  ``` js
+  // ...
+  vue: {
+    // 注意: 别把 `postcss` 配置项放到 `loaders` 里
+    postcss: [require('postcss-cssnext')()],
+    autoprefixer: false,
+    loaders: {
+      // ...
+    }
+  }
+  ```
+
+  这个配置项支持对象类型，包含了传递给 PostCSS 处理器的选项。当你的项目使用 PostCSS，而且依赖自定义的 解析器/生成器 时，用对象类型就很合适：
+
+  ``` js
+  postcss: {
+    plugins: [...], // 插件列表
+    options: {
+      parser: sugarss // 使用 sugarss 解析器
+    }
+  }
+  ```
+
+### cssSourceMap
+
+- 类型: `Boolean`
+- 默认: `true`
+
+  表明是否支持 CSS source map。如果禁用该功能，可以避免 `css-loader` 的一些相对路径引起的 bug，同时加快构建过程。
+
+  注意，如果 Webpack 配置的 `devtool` 选项没有设置，那么该选项会自动设为 `false`。
+
+### template
+
+- ^8.4.0
+- 类型: `Object`
+
+  如果你使用非 HTML 的模板引擎，这个配置可以用来给模板渲染引擎传递配置项 （借助 [consolidate](https://github.com/tj/consolidate.js)）。

--- a/docs/zh-cn/start/spec.md
+++ b/docs/zh-cn/start/spec.md
@@ -1,0 +1,91 @@
+# Vue 组件说明
+
+`*.vue` 是自定义文件格式，使用类似 HTML 语法来描述一个 Vue 组件。每个 `*.vue` 文件由三个顶层的语言块组成，分别是 `<template>`、`<script>` 和 `<style>`：
+
+``` html
+<template>
+  <div class="example">{{ msg }}</div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      msg: 'Hello world!'
+    }
+  }
+}
+</script>
+
+<style>
+.example {
+  color: red;
+}
+</style>
+```
+
+`vue-loader` 会解析这个文件，分别取出每个语言块，如果需要，则连接到其他 loader，最后把每一块结果放回去，拼装成一个 CommonJS 模块，它的 `module.exports` 就是 Vue.js 组件的选项对象（options）。
+
+`vue-loader` 支持使用非默认的语言，例如 CSS 预处理器 和 生成 HTML 的模板语言，只需给语言块指定 `lang` 属性。举个例子，你可以像下面这样给组件的 style 块使用 SASS：
+
+``` html
+<style lang="sass">
+  /* write SASS! */
+</style>
+```
+
+想获得更多详细介绍，查看 [使用预处理器](../configurations/pre-processors.md)。
+
+### 语言块
+
+#### `<template>`
+
+- 默认语言: `html`。
+
+- 每个 `*.vue` 文件最多放一个 `<template>` 块。
+
+- 这部分内容会抽取解析成字符串，作为编译后的 Vue 组件的 `template` 选项。
+
+#### `<script>`
+
+- 默认语言: `js` (借助 Babel，默认支持 ES2015).
+
+- 每个 `*.vue` 最多放一个 `<script>`。
+
+- 里面的代码会在 CommonJS 风格的环境中执行（就像由 Webpack 打包的普通 `.js` 模块一样），这意味着你可以 `require()` 其他依赖的模块。同时因为默认支持 ES2015，所以你可以使用 ES2015 的 `import` 和 `export` 语法。
+
+- 必须 export 一个 Vue.js 组件的选项对象（options），或是 `Vue.extend()` 返回的构造器，不过建议返回选项对象这样的纯对象。
+
+#### `<style>`
+
+- 默认语言: `css`.
+
+- `*.vue` 文件支持多个 `<style>` 标签
+
+- 默认情况下，取出内容，使用 `style-loader` 处理，最终动态地插入到 document 的 `<head>` 中，变成一个真正 `<style>` 标签。
+
+### Src 引用
+
+如果你更喜欢把 `*.vue` 的各部分放在不同的文件，你可以使用 `src` 属性在语言块中引入外部文件。
+
+``` html
+<template src="./template.html"></template>
+<style src="./style.css"></style>
+<script src="./script.js"></script>
+```
+
+要注意的是，使用 `src` 引入资源时，要遵循 CommonJS `require()` 的路径规则，这意味着，如果要用相对路径的话，需要带上 `./`，同时，你可以直接引入安装好的 NPM 包的资源，例如：
+
+``` html
+<!-- 从安装好的 "todomvc-app-css" npm 包引入一个文件 -->
+<style src="todomvc-app-css/index.css">
+```
+
+### 语法高亮
+
+目前支持语法高亮的工具有：[Sublime Text](https://github.com/vuejs/vue-syntax-highlight), [Atom](https://atom.io/packages/language-vue), [Vim](https://github.com/posva/vim-vue), [Visual Studio Code](https://marketplace.visualstudio.com/items/liuji-jim.vue), [Brackets](https://github.com/pandao/brackets-vue), 和 [JetBrains products](https://plugins.jetbrains.com/plugin/8057) (WebStorm, PhpStorm 等等)。 非常欢迎和感谢大家贡献其他编辑器或 IDE 的支持！如果你没用到预处理器，可以在编辑器中把 `*.vue` 文件当作 HTML 文件凑合着用。
+
+### 注释
+
+各个语言块中的注释需要使用对应语言（HTML、CSS、JavaScript、Jade 等等）的注释语法。对于顶级块的注释，则使用 HTML 的注释语法：`<!-- comment contents here -->`
+

--- a/docs/zh-cn/start/tutorial.md
+++ b/docs/zh-cn/start/tutorial.md
@@ -1,0 +1,186 @@
+﻿# 基础指南
+
+接下来，我们会从零开始，逐步搭建一个 Webpack + `vue-loader` 的项目。如果你对准备好的运行例子感兴趣，查看 [vue-cli](https://github.com/vuejs/vue-cli)，借助脚手架快速搭建新项目。不过，如果你不是 Webpack 老司机，我还是非常建议您接着看下面教程，然后理解各部分是怎么配合工作的。
+
+### 项目结构
+
+一个基于 `vue-loader` 的简单项目大概长这样：
+
+``` bash
+.
+├── index.html
+├── main.js
+├── components
+│   ├── App.vue
+│   ├── ComponentA.vue
+│   └── ComponentB.vue
+├── package.json
+└── webpack.config.js
+```
+
+### 安装依赖
+
+在我们敲代码之前，需要安装相应的 NPM 依赖包。我们可以运行：
+
+``` bash
+# 该命令会创建一个 package.json 文件。
+# 根据你的需求对提示的问题填写回答就行
+npm init
+
+# 安装所需的一切
+npm install\
+  webpack webpack-dev-server\
+  vue-loader vue-html-loader css-loader vue-style-loader vue-hot-reload-api\
+  babel-loader babel-core babel-plugin-transform-runtime babel-preset-es2015\
+  babel-runtime\
+  --save-dev
+npm install vue --save
+```
+
+我知道这里确实不少依赖！主要原因是 `vue-loader` 需要把其他 webpack loader 作为 **同级依赖**，而不是深层依赖，这样 Webpack 才能能够找到它们。[^(1)]
+
+> 注意: `vue-loader` 的上个版本，我们通过明确安装 `babel-runtime` 5.x 版本来避免重复依赖 —— 在最近 babel 升级之后，这将不是必须的。
+
+在正确安装依赖后，你的 `package.json` 的 `devDependencies` 字段应该长这样：
+
+``` json
+...
+  "devDependencies": {
+    "babel-core": "^6.3.17",
+    "babel-loader": "^6.2.0",
+    "babel-plugin-transform-runtime": "^6.3.13",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-runtime": "^5.8.34",
+    "css-loader": "^0.23.0",
+    "vue-hot-reload-api": "^1.2.2",
+    "vue-html-loader": "^1.0.0",
+    "vue-style-loader": "^1.0.0",
+    "vue-loader": "^7.2.0",
+    "webpack": "^1.12.9",
+    "webpack-dev-server": "^1.14.0"
+  },
+  "dependencies": {
+    "vue": "^1.0.13"
+  },
+...
+```
+
+### 配置 Webpack
+
+下面是 `vue-loader` 最基本的 Webpack 配置：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // 应用的入口
+  entry: './main.js',
+  // 编译打包后的输出
+  output: {
+    path: __dirname,
+    filename: 'build.js'
+  },
+  module: {
+    // `loaders` 是需要用到的 loader 组成的数组
+    // 这里只配置 vue-loader
+    loaders: [
+      {
+        test: /\.vue$/, // 正则匹配所有以 `.vue` 结尾的文件
+        loader: 'vue'   // 对匹配到的文件使用何种 loader
+      }
+    ]
+  }
+}
+```
+
+有了上面的配置，当你像下面这样写 JavaScript 代码的时候：
+
+``` js
+var MyComponent = require('./my-component.vue')
+```
+
+Webpack 知道它需要把 `./my-component.vue` 的内容连接（pipe）到 `vue-loader`，因为文件名符合配置中的正则表达式。
+
+### 创建其他文件
+
+应用的入口 `main.js` 通常长这样（使用 ES2015 语法）：
+
+``` js
+// main.js
+import Vue from 'vue'
+// 依赖一个 *.vue 组件
+import App from './components/App'
+
+// 挂载 Vue 根实例
+new Vue({
+  el: 'body',
+  components: {
+    // 在配置中包含依赖的组件
+    app: App
+  }
+})
+```
+
+你可以在 `*.vue` 组件的 `<script>` 标签里，依赖多个其它 `*.vue` 组件。例如在 `./components/App.vue` 中：
+
+``` html
+<template>
+  <div class="app">
+    <component-a></component-a>
+    <component-b></component-b>
+  </div>
+</template>
+
+<script>
+import ComponentA from './ComponentA.vue'
+import ComponentB from './ComponentB.vue'
+
+export default {
+  components: {
+    ComponentA,
+    ComponentB
+  }
+}
+</script>
+```
+
+接下来，我们新建一个 `index.html` 文件，简单的使用打包生成的文件：
+
+``` html
+<!-- index.html -->
+<body>
+  <app></app>
+  <script src="build.js"></script>
+</body>
+```
+
+### 运行
+
+最后来运行它！我们用简单的 [NPM scripts](https://docs.npmjs.com/misc/scripts) 作任务运行，大多数情况也够用了。把下面代码添加到 `package.json` 中：
+
+
+``` json
+...
+"scripts": {
+  "dev": "webpack-dev-server --inline --hot",
+  "build": "webpack -p"
+}
+...
+```
+
+然后运行：
+
+``` bash
+npm run dev
+```
+
+接着打开 `http://localhost:8080`，能看到你的应用跑起来了，还带热加载呢！想要构建、压缩，并将打包文件写入磁盘，则运行：
+
+``` bash
+npm run build
+```
+
+要注意的是，Webpack 默认找到 `webpack.config.js` ，把它当作配置文件。如果你的 Webpack 配置文件用别的命名，则需要通过命令行参数 `--config /你的/文件/路径` 来指定配置文件。
+
+---
+
+[^(1)] 如果你用 NPM 2.x 版本，当运行 `npm install vue-loader --save-dev` 时，它会安装保存所有的同级依赖。但是，如果你用的 NPM 是 3.x 版本的，那么这些同级依赖将不再自动安装了，你必须得像上面那样明确安装它们。另一种简单的处理方式就是，复制 `vue-loader` 的同级依赖到你的 `package.json` 文件的 `devDependencies` 字段，然后运行 `npm install`。

--- a/docs/zh-cn/workflow/linting.md
+++ b/docs/zh-cn/workflow/linting.md
@@ -1,0 +1,69 @@
+# 检查代码
+
+你可能已经在怀疑，怎么在 `*.vue` 文件里面检测代码，毕竟它们不是 JavaScript。我们假设你正在使用 [ESLint](http://eslint.org/)（如果你没用，你该用了！）。
+
+你还需要 [eslint-html-plugin](https://github.com/BenoitZugmeyer/eslint-plugin-html) 插件，用来提取和检测 `*.vue` 文件中的 JavaScript。
+
+确保在 ESLint 配置中引入这个插件：
+
+``` json
+"plugins": [
+  "html"
+]
+```
+
+然后在命令行运行：
+
+``` bash
+eslint --ext js,vue MyComponent.vue
+```
+
+另一种选择是使用 [eslint-loader](https://github.com/MoOx/eslint-loader)，这样，在开发阶段，当你在保存 `*.vue` 文件时，会自动检测代码。
+
+``` bash
+npm install eslint eslint-loader --save-dev
+```
+
+``` js
+// webpack.config.js
+module.exports = {
+  // ... other options
+  module: {
+    loaders: [
+      {
+        test: /.vue$/,
+        loader: 'vue!eslint'
+      }
+    ]
+  }
+}
+```
+
+注意，Webpack loader 的调用顺序是 **靠右优先** 执行。要确保 `eslint` 在 `vue` 前面执行，这样我们检测的才是编译前的源码。
+
+有一件事需要多加考虑，就是使用第三方 NPM 包中的 `*.vue` 组件。在这种情况下，我们要使用 `vue-loader` 去处理第三方组件，但是不想检查它的代码。我们可以把检测隔开，放到 Webpack 的
+[preLoaders](https://webpack.github.io/docs/loaders.html#loader-order)：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // ... other options
+  module: {
+    // 只检查本地 *.vue 文件的代码
+    preLoaders: [
+      {
+        test: /.vue$/,
+        loader: 'eslint',
+        exclude: /node_modules/
+      }
+    ],
+    // 对所有 *.vue 文件使用 vue-loader
+    loaders: [
+      {
+        test: /.vue$/,
+        loader: 'vue'
+      }
+    ]
+  }
+}
+```

--- a/docs/zh-cn/workflow/production.md
+++ b/docs/zh-cn/workflow/production.md
@@ -1,0 +1,41 @@
+# 构建用于生产环境
+
+当构建打包文件用于生产环境时，有两件事情要做：
+
+1. 压缩我们的应用代码；
+2. 按照 [Vue.js 教程中描述的步骤](http://vuejs.org/guide/application.html#Deploying_for_Production)，移除 Vue.js 源码中的所有警告代码。
+
+下面是配置例子：
+
+``` js
+// webpack.config.js
+module.exports = {
+  // ... other options
+  plugins: [
+    // 毙掉所有 Vue.js 的警告代码
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
+    // 通过移除“死代码”实现压缩
+    // （译者: 例如 if(true) 就是死代码）
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    }),
+    // 通过比对模块使用频率有话模块 id 
+    //（译者：可能是用得最多的模块用最短的 id 命名吧）
+    new webpack.optimize.OccurenceOrderPlugin()
+  ]
+}
+```
+
+显然，我们不想在开发阶段使用这个配置，所以提供了几种方式来解决：
+
+1. 根据环境变量动态的设置配置；
+
+2. 或者，使用不同的 Webpack 配置文件，一个用于开发环境，一个用于生产，还可以把两者的共同配置放在第三方文件里，正如 [vue-loader 例子](https://github.com/vuejs/vue-loader-example/tree/master/build) 中展示的那样。
+
+只要达到目的，你爱怎么弄就怎么弄。

--- a/docs/zh-cn/workflow/testing-with-mocks.md
+++ b/docs/zh-cn/workflow/testing-with-mocks.md
@@ -1,0 +1,70 @@
+# 用 Mocks 测试
+
+> 这个功能需要 `vue-loader@^7.3.0`。
+
+在实际的应用里，我们的组件很可能有外部依赖，当给组件写单元测试的时候，如果能够模拟这些外部依赖就完美了，这样我们的测试就仅仅依靠测试组件本身的行为。
+
+`vue-loader` 提供了一个功能，借助 [inject-loader](https://github.com/plasticine/inject-loader) 让你可以注入 `*.vue` 组件的任意依赖。大概思路就是，不用真的直接导入模块，而是针对这些模块，使用 `inject-loader` 创建的 “模块工厂” 方法，当工厂方法被调用并传入一个模拟的对象，就会返回相应模块的实例，而模拟对象也注入到该实例里。
+
+假设我们有一个组件，长这样：
+
+``` html
+<!-- example.vue -->
+<template>
+  <div class="msg">{{ msg }}</div>
+</template>
+
+<script>
+// 这个依赖需要 mock
+import SomeService from '../service'
+
+export default {
+  data () {
+    return {
+      msg: SomeService.msg
+    }
+  }
+}
+</script>
+```
+
+下面展示如何导入 mock 之后的模块：
+
+``` bash
+npm install inject-loader --save-dev
+```
+
+``` js
+// example.spec.js
+const ExampleInjector = require('!!vue?inject!./example.vue')
+```
+
+注意到 require 用的奇怪字符串 —— 我们这里使用一些内联的 [webpack loader 请求](https://webpack.github.io/docs/loaders.html)。简单讲解一下：
+
+- 开头的 `!!` 表示 "不用全局配置中的所有 loader";
+- `vue?inject!` 表示 “使用 `vue` loader，然后传入 `?inject` 查询字符串，告诉 `vue-loader` 使用依赖注入（dependency-injection）模式来编译组件。
+
+返回的 `ExampleInjector` 是一个工厂方法，用来创建一个 `example.vue` 模块的实例。
+
+``` js
+const ExampleWithMocks = ExampleInjector({
+  // mock it
+  '../service': {
+    msg: 'Hello from a mocked service!'
+  }
+})
+```
+
+最终，我们可以像平常那样测试这个组件了：
+
+``` js
+it('should render', () => {
+  const vm = new Vue({
+    template: '<div><test></test></div>',
+    components: {
+      'test': ExampleWithMocks
+    }
+  }).$mount()
+  expect(vm.$el.querySelector('.msg').textContent).toBe('Hello from a mocked service!')
+})
+```

--- a/docs/zh-cn/workflow/testing.md
+++ b/docs/zh-cn/workflow/testing.md
@@ -1,0 +1,98 @@
+﻿# 测试
+
+当测试 `*.vue` 文件时，我们不能使用基于原生 CommonJS 的测试执行器，因为它不知道怎么处理 `*.vue` 文件。取而代之的是，依然使用 Webpack + vue-loader 去打包我们的测试文件，建议安装使用 [Karma](http://karma-runner.github.io/0.13/index.html) 和 [karma-webpack](https://github.com/webpack/karma-webpack)。
+
+Karma 是一个测试调度执行器，能够打开浏览器替你执行测试。你可以选择要用哪些浏览器，以及哪些测试框架（如 Mocha 或 Jasmine）。下面是一个 Karma 的配置例子，在 [PhantomJS](http://phantomjs.org/) 中运行测试，其中使用 [Jasmine](http://jasmine.github.io/edge/introduction.html) 测试框架：
+
+``` bash
+npm install\
+  karma karma-webpack\
+  karma-jasmine jasmine-core\
+  karma-phantomjs-launcher phantomjs\
+  --save-dev
+```
+
+``` js
+// 我们可以就用恰似一样的 webpack 配置，通过 require 加载它
+// 不过记得删除原来配置的入口，因为我们测试不需要它
+var webpackConfig = require('./webpack.config.js')
+delete webpackConfig.entry
+
+// karma.conf.js
+module.exports = function (config) {
+  config.set({
+    browsers: ['PhantomJS'],
+    frameworks: ['jasmine'],
+    // 这是所有测试文件的入口文件
+    files: ['test/index.js'],
+    // 把入口文件传给 webpack 去打包
+    preprocessors: {
+      'test/index.js': ['webpack']
+    },
+    // 使用之前的 webpack 配置
+    webpack: webpackConfig,
+    // 避免出现一堆无用的信息
+    webpackMiddleware: {
+      noInfo: true
+    },
+    singleRun: true
+  })
+}
+```
+
+接着，对于入口文件 `test/index.js`：
+
+``` js
+// test/index.js
+// 使用 Webpack 的特殊功能，加载所有测试文件
+// https://webpack.github.io/docs/context.html#require-context
+var testsContext = require.context('.', true, /\.spec$/)
+testsContext.keys().forEach(testsContext)
+```
+
+入口文件只是简单的 require 同目录下，其他所有以 `.spec.js` 结尾的文件。现在我们可以真的来写点测试：
+
+``` js
+// test/component-a.spec.js
+var Vue = require('vue')
+var ComponentA = require('../../src/components/a.vue')
+
+describe('a.vue', function () {
+
+  // asserting JavaScript options
+  it('should have correct message', function () {
+    expect(ComponentA.data().msg).toBe('Hello from Component A!')
+  })
+
+  // asserting rendered result by actually rendering the component
+  it('should render correct message', function () {
+    var vm = new Vue({
+      template: '<div><test></test></div>',
+      components: {
+        'test': ComponentA
+      }
+    }).$mount()
+    expect(vm.$el.querySelector('h2.red').textContent).toBe('Hello from Component A!')
+  })
+})
+```
+
+添加下面的 NPM script 用来运行测试：
+
+``` js
+// package.json
+...
+"scripts": {
+  ...
+  "test": "karma start karma.conf.js"
+}
+...
+```
+
+最后运行:
+
+``` bash
+npm test
+```
+
+再次安利，[vue-loader-example](https://github.com/vuejs/vue-loader-example) 包含完全可跑的测试例子。

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -214,13 +214,14 @@ module.exports = function (content) {
       process.env.NODE_ENV !== 'production' &&
       (parts.script.length || parts.template.length)
     ) {
+      var hotId = JSON.stringify(moduleId + '/' + fileName)
       output +=
         'if (module.hot) {(function () {' +
         '  module.hot.accept()\n' +
         '  var hotAPI = require("vue-hot-reload-api")\n' +
         '  hotAPI.install(require("vue"), false)\n' +
         '  if (!hotAPI.compatible) return\n' +
-        '  var id = ' + loaderUtils.stringifyRequest(loaderContext, filePath) + '\n' +
+        '  var id = ' + hotId + '\n' +
         '  if (!module.hot.data) {\n' +
         // initial insert
         '    hotAPI.createRecord(id, module.exports)\n' +

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,7 @@ var parse = require('./parser')
 var selectorPath = require.resolve('./selector')
 var hash = require('hash-sum')
 var path = require('path')
+var fs = require('fs')
 
 var defaultLang = {
   template: 'html',
@@ -88,6 +89,20 @@ module.exports = function (content) {
 
   function getLoaderString (type, part, scoped) {
     var lang = part.lang || defaultLang[type]
+    var opt = part.opt
+    if (opt) { // to resolve a possible relative given file
+      try {
+        JSON.parse(opt) // if it is valid JSON, no resolving is needed
+      } catch (e) {
+        var newOpt = path.resolve(path.dirname(filePath), opt)
+        try {
+          var stats = fs.lstatSync(newOpt)
+          if (stats.isFile()) {
+            opt = newOpt
+          }
+        } catch (e) {}
+      }
+    }
     var loader = loaders[lang]
     var rewriter = getRewriter(type, scoped)
     var injectString = (type === 'script' && query.inject) ? 'inject!' : ''
@@ -106,7 +121,7 @@ module.exports = function (content) {
       // unknown lang, infer the loader to be used
       switch (type) {
         case 'template':
-          return defaultLoaders.html + '!' + rewriter + templateLoader + '?raw&engine=' + lang + '!'
+          return defaultLoaders.html + '!' + rewriter + templateLoader + '?raw&opt=' + opt + '&engine=' + lang + '!'
         case 'style':
           return defaultLoaders.css + '!' + rewriter + lang + '!'
         case 'script':

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,6 +40,7 @@ module.exports = function (content, filename, needMap) {
     var lang = getAttribute(node, 'lang')
     var src = getAttribute(node, 'src')
     var scoped = getAttribute(node, 'scoped') != null
+    var opt = getAttribute(node, 'opt')
     var warnings = null
     var map = null
 
@@ -69,7 +70,8 @@ module.exports = function (content, filename, needMap) {
       } else if (type === 'template') {
         output.template.push({
           src: src,
-          lang: lang
+          lang: lang,
+          opt: opt
         })
       } else if (type === 'script') {
         output.script.push({
@@ -152,6 +154,7 @@ module.exports = function (content, filename, needMap) {
       lang: lang,
       scoped: scoped,
       content: result,
+      opt: opt,
       map: map && map.toJSON(),
       warnings: warnings
     })

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -27,10 +27,10 @@ module.exports = function (content) {
   }
 
   if (!cons[opt.engine]) {
-    throw new Error(
+    return callback(new Error(
       'Template engine \'' + opt.engine + '\' ' +
       'isn\'t available in Consolidate.js'
-    )
+    ))
   }
 
   // for relative includes
@@ -38,8 +38,9 @@ module.exports = function (content) {
 
   cons[opt.engine].render(content, opt, function (err, html) {
     if (err) {
-      throw err
+      callback(err)
+    } else {
+      exportContent(html)
     }
-    exportContent(html)
   })
 }

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -6,13 +6,20 @@ module.exports = function (content) {
   this.cacheable && this.cacheable()
   var callback = this.async()
   var opt = loaderUtils.parseQuery(this.query)
+  var renderOpts = {}
+  try {
+    renderOpts = JSON.parse(opt.opt)
+  } catch (e) {
+    try {
+      renderOpts = require(opt.opt)
+    } catch (e) {}
+  }
   var vue = this.options.vue
   if (vue && vue.template) {
     for (var key in vue.template) {
-      opt[key] = vue.template[key]
+      renderOpts[key] = vue.template[key]
     }
   }
-
   function exportContent (content) {
     if (opt.raw) {
       callback(null, content)
@@ -36,7 +43,7 @@ module.exports = function (content) {
   // for relative includes
   opt.filename = this.resourcePath
 
-  cons[opt.engine].render(content, opt, function (err, html) {
+  cons[opt.engine].render(content, renderOpts, function (err, html) {
     if (err) {
       callback(err)
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-loader",
-  "version": "8.5.2",
+  "version": "8.5.3",
   "description": "Vue.js component loader for Webpack",
   "main": "index.js",
   "repository": {

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -1,0 +1,3 @@
+{
+  "pretty": true
+}

--- a/test/fixtures/options.vue
+++ b/test/fixtures/options.vue
@@ -1,0 +1,4 @@
+<template lang="jade" opt="./options.json">
+div
+  div #{pretty}
+</template>

--- a/test/fixtures/options2.vue
+++ b/test/fixtures/options2.vue
@@ -1,0 +1,4 @@
+<template lang="jade" opt='{"pretty":true}'>
+div
+  div #{pretty}
+</template>

--- a/test/test.js
+++ b/test/test.js
@@ -276,4 +276,24 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('template opt prop - json file', function (done) {
+    test({
+      entry: './test/fixtures/options.vue'
+    }, function (window) {
+      var module = window.vueModule
+      expect(module.template).to.contain('\n<div>\n  <div>true</div>\n</div>')
+      done()
+    })
+  })
+
+  it('template opt prop - inline json', function (done) {
+    test({
+      entry: './test/fixtures/options2.vue'
+    }, function (window) {
+      var module = window.vueModule
+      expect(module.template).to.contain('\n<div>\n  <div>true</div>\n</div>')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
allows following syntax:

``` vue
<template lang='pug' opt='{"pretty":true}'>
</template>
// and
<template lang='pug' opt='options.json'>
</template>
```

the resolved opt object will be forwarded to the templating engine.

With unit test but without documentation (yet)
