### PR TITLE
add esModule support

### DIFF
--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -73,3 +73,11 @@
 - type: `Object`
 
   Pass options to the template rendering engine (via [consolidate](https://github.com/tj/consolidate.js)) if you are using a non-html templating language.
+
+### esModule
+
+- ^9.4.3
+- type: `Boolean`
+- default: `undefined`
+
+  Whether to emit esModule compatible code. By default vue-loader will emit default export in commonjs format like `module.exports = ....`. When `esModule` is set to true, default export will be transpiled into `exports.__esModule = true; exports = ...`. Useful for interoperating with transpiler other than Bable, like TypeScript.

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -236,7 +236,11 @@ module.exports = function (content) {
         '")}\n'
     }
     // final export
-    output += '\nmodule.exports = __vue_exports__\n'
+    if (options.esModule) {
+      output += '\nexports.__esModule = true;\nexports["default"] = __vue_exports__\n'
+    } else {
+      output += '\nmodule.exports = __vue_exports__\n'
+    }
   } else {
     // inject-loader support
     output +=

--- a/test/test.js
+++ b/test/test.js
@@ -348,4 +348,24 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('support es compatible modules', function (done) {
+    test({
+      entry: './test/fixtures/basic.vue',
+      vue: {
+        esModule: true
+      }
+    }, function (window, module, rawModule) {
+      expect(rawModule.__esModule).to.equal(true)
+      var vnode = mockRender(rawModule.default, {
+        msg: 'hi'
+      })
+      expect(vnode.tag).to.equal('h2')
+      expect(vnode.data.staticClass).to.equal('red')
+      expect(vnode.children[0]).to.equal('hi')
+
+      expect(rawModule.default.data().msg).to.contain('Hello from Component A!')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This pull request adds an alternative module export mechanism.

For [some language](https://github.com/Microsoft/TypeScript/issues/2242), `export default ...` is not transpiled to `module.exports = ....`.

When `vue` option's `esModule` is set to `true`, vue-loader will produce code like below:

```js
exports.__esModule = true
exports["default"] = __vue_exports__
```

I think some tests and docs are needed. If you think this approach is acceptable, please let me know and I will add required tests.