### PR TITLE
[Fix for Webpack 2 Beta 24+] Get loader options from query instead of raw this.options

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,7 +42,7 @@ module.exports = function (content) {
   var isServer = this.options.target === 'node'
   var loaderContext = this
   var query = loaderUtils.parseQuery(this.query)
-  var options = this.options.vue || query || {}
+  var options = this.query ? query : this.vue || this.options.vue || {}
   var filePath = this.resourcePath
   var fileName = path.basename(filePath)
   var moduleId = 'data-v-' + genId(filePath)

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -41,8 +41,8 @@ module.exports = function (content) {
   this.cacheable()
   var isServer = this.options.target === 'node'
   var loaderContext = this
-  var options = this.vue || this.options.vue || {}
   var query = loaderUtils.parseQuery(this.query)
+  var options = this.options.vue || query || {}
   var filePath = this.resourcePath
   var fileName = path.basename(filePath)
   var moduleId = 'data-v-' + genId(filePath)


### PR DESCRIPTION
The current way to handle Webpack 2 Beta 24+ involves the use of `LoaderOptionsPlugin`. This is non-ideal, as `LoaderOptionsPlugin` actually mangles `this.options` in loaders to refer to its configuration instead of what webpack normally passes. Because of this, `LoaderOptionsPlugin` should be used only as a stopgap until a fix is introduced to make the loader compatible with Webpack 2 Beta 24+ by loading its options from `this.query` instead of `this.options.x`.

[Current Usage](https://github.com/vuejs/vue-hackernews-2.0/blob/master/build/webpack.base.config.js#L38-L40) (`LoaderOptionsPlugin`):
```javascript
module.exports = {
  ...
  module: {
    rules: [
      {
        test: /\.vue$/,
        loader: 'vue'
      },
      ...
    ]
  },
  plugins: [
    new webpack.LoaderOptionsPlugin({
      vue: {
        ...
      }
    })
  ]
}
```

[Recommended Usage (Works after this patch)](https://github.com/webpack/webpack/issues/3018#issuecomment-248231784) (Current and Webpack 1.x usages still work and can mix & match):
```javascript
module.exports = {
  ...
  module: {
    rules: [
      {
        test: /\.vue$/,
        loader: 'vue',
        options: { // query works as well here.
          vue: {
            ...
          }
        }
      },
      ...
    ]
  }
}
```

I hope this is of use. The removal of references to `this.options` may cause breakages in Webpack 1.x, though all tests are passing. If someone wants to confirm this, feel free.