### PR TITLE
remove css-loader from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "vue-template-compiler": "^2.0.0-rc.3",
     "vue-template-es2015-compiler": "^1.0.0"
   },
-  "peerDependencies": {
-    "css-loader": "*"
-  },
   "devDependencies": {
     "babel-core": "^6.8.0",
     "babel-loader": "^6.2.4",


### PR DESCRIPTION
Since npm3+,it will not install peerDependencies automatically.when I run `npm shrinkWrap --dev`,it shows the error:**peer invalid: css-loader@*, required by vue-loader@9.7.0**
