### PR TITLE
[WIP]CSS modules

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -180,22 +180,21 @@ module.exports = function (content) {
   if (parts.styles.length) {
     output += '\n/* styles */\n'
     parts.styles.forEach(function (style, i) {
-      /* !HACK! */
-      style.module = i === 0 ? 'style' : '$style'
+      var moduleName = (style.module === true) ? '$style' : style.module
 
       // require style
-      if (isServer && !style.module) return
+      if (isServer && !moduleName) return
       var requireString = style.src
         ? getRequireForImport('styles', style, style.scoped)
         : getRequire('styles', style, i, style.scoped)
 
       // setCssModule
-      if (style.module) {
-        if (style.module in cssModules) {
-          loaderContext.emitError('CSS module name "' + style.module + '" is not unique!')
+      if (moduleName) {
+        if (moduleName in cssModules) {
+          loaderContext.emitError('CSS module name "' + moduleName + '" is not unique!')
           output += requireString
         } else {
-          cssModules[style.module] = true
+          cssModules[moduleName] = true
 
           // `style-loader` exposes the name-to-hash map directly
           // `css-loader` exposes it in `.locals`
@@ -204,7 +203,7 @@ module.exports = function (content) {
             requireString += '.locals'
           }
 
-          output += '__vue_styles__["' + style.module + '"] = ' + requireString + '\n'
+          output += '__vue_styles__["' + moduleName + '"] = ' + requireString + '\n'
         }
       } else {
         output += requireString

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -58,7 +58,7 @@ module.exports = function (content) {
   var bubleOptions = hasBuble && options.buble ? '?' + JSON.stringify(options.buble) : ''
   var defaultLoaders = {
     html: templateCompilerPath + '?id=' + moduleId,
-    css: styleLoaderPath + '!css-loader' + (needCssSourceMap ? '?sourceMap' : ''),
+    css: (isServer ? '' : styleLoaderPath + '!') + 'css-loader' + (needCssSourceMap ? '?sourceMap' : ''),
     js: hasBuble ? ('buble-loader' + bubleOptions) : hasBabel ? 'babel-loader' : ''
   }
 
@@ -177,14 +177,18 @@ module.exports = function (content) {
   var cssModules = {}
 
   // add requires for styles
-  if (!isServer && parts.styles.length) {
+  if (parts.styles.length) {
     output += '\n/* styles */\n'
     parts.styles.forEach(function (style, i) {
       /* !HACK! */
       style.module = i === 0 ? 'style' : '$style'
+
+      // require style
+      if (isServer && !style.module) return
       var requireString = style.src
         ? getRequireForImport('styles', style, style.scoped)
         : getRequire('styles', style, i, style.scoped)
+
       // setCssModule
       if (style.module) {
         if (style.module in cssModules) {
@@ -192,6 +196,14 @@ module.exports = function (content) {
           output += requireString
         } else {
           cssModules[style.module] = true
+
+          // `style-loader` exposes the name-to-hash map directly
+          // `css-loader` exposes it in `.locals`
+          // We drop `style-loader` in SSR, and add `.locals` here.
+          if (isServer) {
+            requireString += '.locals'
+          }
+
           output += '__vue_styles__["' + style.module + '"] = ' + requireString + '\n'
         }
       } else {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -77,7 +77,7 @@ module.exports = function (content) {
       // disable all configuration loaders
       '!!' +
       // get loader string for pre-processors
-      getLoaderString(type, part, scoped) +
+      getLoaderString(type, part, index, scoped) +
       // select the corresponding part from the vue file
       getSelectorString(type, index || 0) +
       // the url to the actual vuefile
@@ -94,17 +94,41 @@ module.exports = function (content) {
   function getRequireForImportString (type, impt, scoped) {
     return loaderUtils.stringifyRequest(loaderContext,
       '!!' +
-      getLoaderString(type, impt, scoped) +
+      getLoaderString(type, impt, -1, scoped) +
       impt.src
     )
   }
 
-  function getLoaderString (type, part, scoped) {
+  function addCssModulesToLoader (loader, part, index) {
+    if (!part.module) return loader
+    return loader.replace(/((?:^|!)css(?:-loader)?)(\?[^!]*)?/, function (m, $1, $2) {
+      // $1: !css-loader
+      // $2: ?a=b
+      var option = loaderUtils.parseQuery($2)
+      option.modules = true
+      option.importLoaders = true
+      option.localIdentName = '[hash:base64]'
+      if (index !== -1) {
+        // Note:
+        //   Class name is generated according to its filename.
+        //   Different <style> tags in the same .vue file may generate same names.
+        //   Append `_[index]` to class name to avoid this.
+        option.localIdentName += '_' + index
+      }
+      return $1 + '?' + JSON.stringify(option)
+    })
+  }
+
+  function getLoaderString (type, part, index, scoped) {
     var lang = part.lang || defaultLang[type]
     var loader = loaders[lang]
     var rewriter = type === 'styles' ? styleRewriter + (scoped ? '&scoped=true!' : '!') : ''
     var injectString = (type === 'script' && query.inject) ? 'inject!' : ''
     if (loader !== undefined) {
+      // add css modules
+      if (type === 'styles') {
+        loader = addCssModulesToLoader(loader, part, index)
+      }
       // inject rewriter before css/html loader for
       // extractTextPlugin use cases
       if (rewriterInjectRE.test(loader)) {
@@ -121,7 +145,8 @@ module.exports = function (content) {
         case 'template':
           return defaultLoaders.html + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
         case 'styles':
-          return defaultLoaders.css + '!' + rewriter + lang + '!'
+          loader = addCssModulesToLoader(defaultLoaders.css, part, index)
+          return loader + '!' + rewriter + lang + '!'
         case 'script':
           return injectString + lang + '!'
       }
@@ -146,13 +171,31 @@ module.exports = function (content) {
   var hasScoped = parts.styles.some(function (s) { return s.scoped })
   var output = 'var __vue_exports__, __vue_options__\n'
 
+  // css modules
+  output += 'var __vue_styles__ = {}\n'
+  var cssModules = {}
+
   // add requires for styles
   if (!isServer && parts.styles.length) {
     output += '\n/* styles */\n'
     parts.styles.forEach(function (style, i) {
-      output += style.src
+      /* !HACK! */
+      style.module = i === 0 ? 'style' : '$style'
+      var requireString = style.src
         ? getRequireForImport('styles', style, style.scoped)
         : getRequire('styles', style, i, style.scoped)
+      // setCssModule
+      if (style.module) {
+        if (style.module in cssModules) {
+          loaderContext.emitError('CSS module name "' + style.module + '" is not unique!')
+          output += requireString
+        } else {
+          cssModules[style.module] = true
+          output += '__vue_styles__["' + style.module + '"] = ' + requireString + '\n'
+        }
+      } else {
+        output += requireString
+      }
     })
   }
 
@@ -203,6 +246,16 @@ module.exports = function (content) {
   // attach scoped id
   if (hasScoped) {
     exports += '__vue_options__._scopeId = "' + moduleId + '"\n'
+  }
+
+  if (Object.keys(cssModules).length) {
+    // inject style modules as computed properties
+    exports +=
+      'if (!__vue_options__.computed) __vue_options__.computed = {}\n' +
+      'Object.keys(__vue_styles__).forEach(function (key) {\n' +
+        'var module = __vue_styles__[key]\n' +
+        '__vue_options__.computed[key] = function () { return module }\n' +
+      '})\n'
   }
 
   if (!query.inject) {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -101,21 +101,22 @@ module.exports = function (content) {
 
   function addCssModulesToLoader (loader, part, index) {
     if (!part.module) return loader
+    var option = options.cssModules || {}
     return loader.replace(/((?:^|!)css(?:-loader)?)(\?[^!]*)?/, function (m, $1, $2) {
       // $1: !css-loader
       // $2: ?a=b
-      var option = loaderUtils.parseQuery($2)
-      option.modules = true
-      option.importLoaders = true
-      option.localIdentName = '[hash:base64]'
+      var query = loaderUtils.parseQuery($2)
+      query.modules = true
+      query.importLoaders = true
+      query.localIdentName = option.localIdentName || '[hash:base64]'
       if (index !== -1) {
         // Note:
         //   Class name is generated according to its filename.
         //   Different <style> tags in the same .vue file may generate same names.
         //   Append `_[index]` to class name to avoid this.
-        option.localIdentName += '_' + index
+        query.localIdentName += '_' + index
       }
-      return $1 + '?' + JSON.stringify(option)
+      return $1 + '?' + JSON.stringify(query)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "source-map": "^0.5.6",
     "vue-hot-reload-api": "^2.0.1",
     "vue-style-loader": "^1.0.0",
-    "vue-template-compiler": "^2.0.0-rc.3",
+    "vue-template-compiler": "git://github.com/YiSiWang/vue-template-compiler.git#fc2ce58",
     "vue-template-es2015-compiler": "^1.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "source-map": "^0.5.6",
     "vue-hot-reload-api": "^2.0.1",
     "vue-style-loader": "^1.0.0",
-    "vue-template-compiler": "git://github.com/YiSiWang/vue-template-compiler.git#fc2ce58",
+    "vue-template-compiler": "^2.0.4",
     "vue-template-es2015-compiler": "^1.0.0"
   },
   "peerDependencies": {
@@ -72,7 +72,7 @@
     "stylus": "^0.54.5",
     "stylus-loader": "^2.0.0",
     "sugarss": "^0.1.3",
-    "vue": "^2.0.0-rc.4",
+    "vue": "^2.0.4",
     "webpack": "^1.12.2"
   }
 }

--- a/test/fixtures/css-modules.vue
+++ b/test/fixtures/css-modules.vue
@@ -1,0 +1,20 @@
+<style module="style">
+.red {
+  color: red;
+}
+@keyframes fade {
+  from { opacity: 1; } to { opacity: 0; }
+}
+.animate {
+  animation: fade 1s;
+}
+</style>
+
+<style scoped lang="stylus" module>
+.red
+  color: red
+</style>
+
+<script>
+module.exports = {}
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,7 @@ function bundle (options, cb) {
       })
     }
     expect(stats.compilation.errors).to.be.empty
+    require('fs').writeFileSync('./test.build.js', mfs.readFileSync('/test.build.js').toString())
     cb(mfs.readFileSync('/test.build.js').toString())
   })
 }
@@ -378,7 +379,7 @@ describe('vue-loader', function () {
     })
   })
 
-  it('css-modules', function (done) {
+  it.only('css-modules', function (done) {
     test({
       entry: './test/fixtures/css-modules.vue'
     }, function (window) {
@@ -404,7 +405,7 @@ describe('vue-loader', function () {
       // default module + pre-processor + scoped
       var anotherClassName = module.computed.$style().red
       expect(anotherClassName).to.match(/^_/).and.not.equal(className)
-      var id = '_v-' + hash(require.resolve('./fixtures/css-modules.vue'))
+      var id = 'data-v-' + genId(require.resolve('./fixtures/css-modules.vue'))
       expect(style).to.contain('.' + anotherClassName + '[' + id + ']')
 
       done()

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,6 @@ function bundle (options, cb) {
       })
     }
     expect(stats.compilation.errors).to.be.empty
-    require('fs').writeFileSync('./test.build.js', mfs.readFileSync('/test.build.js').toString())
     cb(mfs.readFileSync('/test.build.js').toString())
   })
 }
@@ -426,7 +425,7 @@ describe('vue-loader', function () {
     })
   })
 
-  it.only('css-modules in SSR', function (done) {
+  it('css-modules in SSR', function (done) {
     bundle({
       entry: './test/fixtures/css-modules.vue',
       target: 'node',
@@ -443,7 +442,8 @@ describe('vue-loader', function () {
       }
 
       var output = requireFromString(code, './test.build.js')
-      expect(output.computed.style().red).to.match(/^_/)
+      expect(output.computed.style().red).to.exist
+
       done()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -427,21 +427,23 @@ describe('vue-loader', function () {
   })
 
   it.only('css-modules in SSR', function (done) {
-    test({
+    bundle({
       entry: './test/fixtures/css-modules.vue',
-      vue: {
-        target: 'node'
+      target: 'node',
+      output: Object.assign({}, globalConfig.output, {
+        libraryTarget: 'commonjs2'
+      })
+    }, function (code) {
+      // http://stackoverflow.com/questions/17581830/load-node-js-module-from-string-in-memory
+      function requireFromString(src, filename) {
+        var Module = module.constructor;
+        var m = new Module();
+        m._compile(src, filename);
+        return m.exports;
       }
-    }, function (window) {
-      var module = window.vueModule
 
-      // class name
-      var className = module.computed.style().red
-      expect(className).to.match(/^_/)
-
-      // no css
-      expect(window.document.querySelector('style')).to.not.exist()
-
+      var output = requireFromString(code, './test.build.js')
+      expect(output.computed.style().red).to.match(/^_/)
       done()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -377,4 +377,37 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('css-modules', function (done) {
+    test({
+      entry: './test/fixtures/css-modules.vue'
+    }, function (window) {
+      var module = window.vueModule
+
+      // get local class name
+      var className = module.computed.style().red
+      expect(className).to.match(/^_/)
+
+      // class name in style
+      var style = [].slice.call(window.document.querySelectorAll('style')).map(function (style) {
+        return style.textContent
+      }).join('\n')
+      expect(style).to.contain('.' + className + ' {\n  color: red;\n}')
+
+      // animation name
+      var match = style.match(/@keyframes\s+(\S+)\s+{/)
+      expect(match).to.have.length(2)
+      var animationName = match[1]
+      expect(animationName).to.not.equal('fade')
+      expect(style).to.contain('animation: ' + animationName + ' 1s;')
+
+      // default module + pre-processor + scoped
+      var anotherClassName = module.computed.$style().red
+      expect(anotherClassName).to.match(/^_/).and.not.equal(className)
+      var id = '_v-' + hash(require.resolve('./fixtures/css-modules.vue'))
+      expect(style).to.contain('.' + anotherClassName + '[' + id + ']')
+
+      done()
+    })
+  })
 })


### PR DESCRIPTION
@yyx990803 
2.x uses `vue-template-compiler`, which doesn't expose non standard props (`module`) on `<style>` tag.

Should we use `data-module` instead or modify `vue-template-compiler` to expose non standard props?

I prefer the later cause `scoped` was removed from standard.
