### PR TITLE
Set render functions in Constructor's extendOptions

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -178,8 +178,11 @@ module.exports = function (content) {
       (isProduction ? '' : checkNamedExports) +
       '__vue_options__ = __vue_exports__ = __vue_exports__.default\n' +
     '}\n' +
+    // for constructor export extendOptions
+    'var extendOptions = __vue_options__.extendOptions\n' +
     // constructor export interop
     'if (typeof __vue_options__ === "function") {\n' +
+    '  extendOptions = __vue_options__.extendOptions\n' +
     '  __vue_options__ = __vue_options__.options\n' +
     '}\n' +
     // add filename in dev
@@ -197,7 +200,11 @@ module.exports = function (content) {
     // attach render functions to exported options
     exports +=
       '__vue_options__.render = __vue_template__.render\n' +
-      '__vue_options__.staticRenderFns = __vue_template__.staticRenderFns\n'
+      '__vue_options__.staticRenderFns = __vue_template__.staticRenderFns\n' +
+      'if (extendOptions) {\n' +
+      '  extendOptions.render = __vue_template__.render\n' +
+      '  extendOptions.staticRenderFns = __vue_template__.staticRenderFns\n' +
+      '}\n'
   }
 
   // attach scoped id

--- a/test/test.js
+++ b/test/test.js
@@ -351,6 +351,7 @@ describe('vue-loader', function () {
       var vnode = mockRender(Module.options, {
         msg: 'success'
       })
+      expect(Module.extendOptions).to.haveOwnProperty('render')
       expect(vnode.tag).to.equal('div')
       expect(vnode.children[0]).to.equal('success')
       expect(new Module().msg === 'success')


### PR DESCRIPTION
Fix https://github.com/vuejs/vue-loader/issues/432 and https://github.com/vuejs/vue/issues/4052

When users have `Vue.mixin(globalMixin)`, vue-loader will fail for constructor style export because `Ctor.options` is replaced and `redner` function lost.

In vue's core code. `resolveCtorOptions` will compute the options for a consturctor by merging `extendOptions` and `SuperOptions`. `Vue.mixin` will reset `SuperOptions` and constructor's option is replaced. So `render` function which vue-loader set is lost. However, if `extendOptions` has `render`, newly created options will preserve `render` function.
