### PR TITLE
more options can be passed to `css-loader`

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -102,7 +102,6 @@ module.exports = function (content) {
   function addCssModulesToLoader (loader, part, index) {
     if (!part.module) return loader
     var DEFAULT_OPTIONS = {
-      modules: true,
       camelCase: false,
       localIdentName: '[hash:base64]'
     }
@@ -112,6 +111,7 @@ module.exports = function (content) {
       // $2: ?a=b
       var query = loaderUtils.parseQuery($2)
       Object.assign(query, DEFAULT_OPTIONS, option)
+      query.modules = true
       query.importLoaders = true
       if (index !== -1) {
         // Note:

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -101,14 +101,18 @@ module.exports = function (content) {
 
   function addCssModulesToLoader (loader, part, index) {
     if (!part.module) return loader
+    var DEFAULT_OPTIONS = {
+      modules: true,
+      camelCase: false,
+      localIdentName: '[hash:base64]'
+    }
     var option = options.cssModules || {}
     return loader.replace(/((?:^|!)css(?:-loader)?)(\?[^!]*)?/, function (m, $1, $2) {
       // $1: !css-loader
       // $2: ?a=b
       var query = loaderUtils.parseQuery($2)
-      query.modules = true
+      Object.assign(query, DEFAULT_OPTIONS, option)
       query.importLoaders = true
-      query.localIdentName = option.localIdentName || '[hash:base64]'
       if (index !== -1) {
         // Note:
         //   Class name is generated according to its filename.


### PR DESCRIPTION
`camelCase` is a very important option which can be passed into `css-loader`, so I'm try to merge the `query` by custom `option`.