### PR TITLE
use `Object.assign` to merge cssModules configuration `query` with `option`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ npm-debug.log
 test/output
 docs/_book
 .DS_Store
+.idea
+*.iml

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -102,13 +102,18 @@ module.exports = function (content) {
   function addCssModulesToLoader (loader, part, index) {
     if (!part.module) return loader
     var option = options.cssModules || {}
+    var DEFAULT_OPTIONS = {
+      modules: true,
+      importLoaders: true
+    }
+    var OPTIONS = {
+      localIdentName: '[hash:base64]'
+    }
     return loader.replace(/((?:^|!)css(?:-loader)?)(\?[^!]*)?/, function (m, $1, $2) {
       // $1: !css-loader
       // $2: ?a=b
       var query = loaderUtils.parseQuery($2)
-      query.modules = true
-      query.importLoaders = true
-      query.localIdentName = option.localIdentName || '[hash:base64]'
+      Object.assign(query, OPTIONS, option, DEFAULT_OPTIONS)
       if (index !== -1) {
         // Note:
         //   Class name is generated according to its filename.

--- a/test/test.js
+++ b/test/test.js
@@ -383,7 +383,7 @@ describe('vue-loader', function () {
       test({
         entry: './test/fixtures/css-modules.vue',
         vue: {
-          cssModules: {
+          cssModules: localIdentName && {
             localIdentName: localIdentName
           }
         }


### PR DESCRIPTION
So that more options can be used instead of listing them specifically like `camelCase`.

And maybe there is no need to override the undefined localIdentName option which is passed customly.