### PR TITLE
[Fix for Webpack 2 Beta 26+] Explicitly declare inferred loaders by their full name (#464)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -149,12 +149,12 @@ module.exports = function (content) {
       // unknown lang, infer the loader to be used
       switch (type) {
         case 'template':
-          return defaultLoaders.html + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
+          return defaultLoaders.html + '!' + templateLoaderPath + '?raw-loader&engine=' + lang + '!'
         case 'styles':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
-          return loader + '!' + rewriter + lang + '!'
+          return loader + '!' + rewriter + lang + '-loader!'
         case 'script':
-          return injectString + lang + '!'
+          return injectString + lang + '-loader!'
       }
     }
   }


### PR DESCRIPTION
* In Webpack 2 loaders have to be explicitly declared, the "-loader" part of their name is no longer implied.

This change assumes the use case where lang already ended with '-loader' is not typical or preferred.