### PR TITLE
module="a"  => this.a

### DIFF
--- a/docs/en/features/css-modules.md
+++ b/docs/en/features/css-modules.md
@@ -66,11 +66,11 @@ You can have more than one `<style>` tags in a single `*.vue` component. To avoi
 
 ``` html
 <style module="a">
-  /* identifiers injected as $a */
+  /* identifiers injected as a */
 </style>
 
 <style module="b">
-  /* identifiers injected as $b */
+  /* identifiers injected as b */
 </style>
 ```
 


### PR DESCRIPTION
when i test , i add a keyword `module = "a"` to the style, i find that it is on the instance with `a` not `$a`