### PR TITLE
When name isn’t specified use the filename as the component name.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -256,6 +256,12 @@ module.exports = function (content) {
     // add filename in dev
     (isProduction ? '' : ('__vue_options__.__file = ' + JSON.stringify(filePath))) + '\n'
 
+  // add component name based on the filename
+  exports +=
+    'if(typeof __vue_options__.name === "undefined") {\n' +
+    '  __vue_options__.name = ' + JSON.stringify(path.parse(filePath).name) + '\n' +
+    '}'
+
   // add require for template
   var template = parts.template
   if (template) {

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,7 @@ describe('vue-loader', function () {
     test({
       entry: './test/fixtures/basic.vue'
     }, function (window, module, rawModule) {
+      expect(module.name).to.equal('basic')
       var vnode = mockRender(module, {
         msg: 'hi'
       })


### PR DESCRIPTION
Improves the Vue.js devtools experience, no more “< Anonymous Component >”