### PR TITLE
fix lib/normaliz.js path.resolve

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -6,7 +6,8 @@ exports.lib = function (file) {
   if (IS_TEST) {
     return path.resolve(__dirname, file)
   } else {
-    return 'vue-loader/lib/' + file
+    return path.resolve(__dirname, file)
+
   }
 }
 
@@ -15,7 +16,7 @@ exports.dep = function (dep) {
     return dep
   } else if (fs.existsSync(path.resolve(__dirname, '../node_modules', dep))) {
     // npm 2 or npm linked
-    return 'vue-loader/node_modules/' + dep
+    return path.resolve(__dirname, '../node_modules', dep)
   } else {
     // npm 3
     return dep


### PR DESCRIPTION
Hii，我们有一个基于webpack的前端开发工具，hiipack；该工具把webpack、babel进行统一管理，而对具体业务使用的框架由自己配置；
我们面临的业务情况是：vue-loader安装在了自己的工程目录里，而业务代码在hiipack运行时把源码缓存到了/tmp临时文件夹中，因此会造成代码中的路径错误；

浏览器报错：
`Uncaught Error: Cannot find module "!!./../../../../../../usr/local/lib/node_modules/hiipack/node_modules/extract-text-webpack-plugin/loader.js?{"omit":1,"extract":true,"remove":true}!./../../node_modules/vue-style-loader/index.js!css!vue-loader/lib/style-rewriter?id=data-v-6366894d!sass!vue-loader/lib/selector?type=styles&index=0!./App.vue"`

控制台报错：
`Module not found: Error: Cannot resolve module 'vue-loader/lib/style-rewriter' in /work/path/src/components
Module not found: Error: Cannot resolve module 'vue-loader/lib/selector' in /work/path/src/components
...`

我们按如下修改以后，可以解决该问题，希望能采纳，谢谢