### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "normalize-newline": "^3.0.0",
     "postcss": "^5.0.21",
     "pug": "^2.0.0-beta6",
-    "rimraf": "^2.4.0",
     "stylus": "^0.54.5",
     "stylus-loader": "^2.0.0",
     "sugarss": "^0.2.0",

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,6 @@ var webpack = require('webpack')
 var MemoryFS = require('memory-fs')
 var jsdom = require('jsdom')
 var expect = require('chai').expect
-var rimraf = require('rimraf')
 var genId = require('../lib/gen-id')
 var SourceMapConsumer = require('source-map').SourceMapConsumer
 var ExtractTextPlugin = require("extract-text-webpack-plugin")


### PR DESCRIPTION
As of [ff5e94f](https://github.com/vuejs/vue-loader/commit/ff5e94fcd6b56ea3889a90c0c240a973c155dcff), this dependency is no longer needed.