### PR TITLE
使用10.x的named exports判断方式

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -216,9 +216,7 @@ module.exports = function (content) {
     // check and warn named exports
     if (!this.minimize) {
       output +=
-        'if (__vue_script__ &&\n' +
-        '    __vue_script__.__esModule &&\n' +
-        '    Object.keys(__vue_script__).length > 1) {\n' +
+        'if (Object.keys(__vue_script__).some(function (key) { return key !== "default" && key !== "__esModule" })) {\n' +
         '  console.warn(' + JSON.stringify(
             '[vue-loader] ' + path.relative(process.cwd(), filePath) +
             ': named exports in *.vue files are ignored.'


### PR DESCRIPTION
解决在webpack中配置了babel的sage-x之后引起的Object.keys(__vue_script__).length === 2引起误报的问题