### PR TITLE
Add the vue template compiler onto any template loader specified in the vue.loaders configuration

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -57,10 +57,11 @@ module.exports = function (content) {
 
   var bubleOptions = hasBuble && options.buble ? '?' + JSON.stringify(options.buble) : ''
   var defaultLoaders = {
-    html: templateCompilerPath + '?id=' + moduleId,
+    html: '',
     css: (isServer ? '' : styleLoaderPath + '!') + 'css-loader' + (needCssSourceMap ? '?sourceMap' : ''),
     js: hasBuble ? ('buble-loader' + bubleOptions) : hasBabel ? 'babel-loader' : ''
   }
+  var templateCompilerLoaderCommand = templateCompilerPath + '?id=' + moduleId
 
   // check if there are custom loaders specified via
   // webpack config, otherwise use defaults
@@ -147,6 +148,9 @@ module.exports = function (content) {
       if (type === 'styles') {
         loader = addCssModulesToLoader(loader, part, index)
       }
+      if (type === 'template') {
+        loader = templateCompilerLoaderCommand + '!' + loader
+      }
       // inject rewriter before css/html loader for
       // extractTextPlugin use cases
       if (rewriterInjectRE.test(loader)) {
@@ -161,7 +165,7 @@ module.exports = function (content) {
       // unknown lang, infer the loader to be used
       switch (type) {
         case 'template':
-          return defaultLoaders.html + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
+          return templateCompilerLoaderCommand + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
         case 'styles':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
           return loader + '!' + rewriter + ensureBang(ensureLoader(lang))

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -57,11 +57,10 @@ module.exports = function (content) {
 
   var bubleOptions = hasBuble && options.buble ? '?' + JSON.stringify(options.buble) : ''
   var defaultLoaders = {
-    html: '',
+    html: templateCompilerPath + '?id=' + moduleId,
     css: (isServer ? '' : styleLoaderPath + '!') + 'css-loader' + (needCssSourceMap ? '?sourceMap' : ''),
     js: hasBuble ? ('buble-loader' + bubleOptions) : hasBabel ? 'babel-loader' : ''
   }
-  var templateCompilerLoaderCommand = templateCompilerPath + '?id=' + moduleId
 
   // check if there are custom loaders specified via
   // webpack config, otherwise use defaults
@@ -148,8 +147,9 @@ module.exports = function (content) {
       if (type === 'styles') {
         loader = addCssModulesToLoader(loader, part, index)
       }
-      if (type === 'template') {
-        loader = templateCompilerLoaderCommand + '!' + loader
+      // if user defines custom loaders for html, add template compiler to it
+      if (type === 'template' && loader !== defaultLoaders.html) {
+        loader = defaultLoaders.html + '!' + loader
       }
       // inject rewriter before css/html loader for
       // extractTextPlugin use cases
@@ -165,7 +165,7 @@ module.exports = function (content) {
       // unknown lang, infer the loader to be used
       switch (type) {
         case 'template':
-          return templateCompilerLoaderCommand + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
+          return defaultLoaders.html + '!' + templateLoaderPath + '?raw&engine=' + lang + '!'
         case 'styles':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
           return loader + '!' + rewriter + ensureBang(ensureLoader(lang))

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "file-loader": "^0.9.0",
     "inject-loader": "^2.0.0",
     "jsdom": "^9.2.1",
+    "marked": "^0.3.6",
     "memory-fs": "^0.3.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",

--- a/test/fixtures/markdown.vue
+++ b/test/fixtures/markdown.vue
@@ -1,0 +1,1 @@
+<template>## {{msg}}</template>

--- a/test/test.js
+++ b/test/test.js
@@ -497,4 +497,24 @@ describe('vue-loader', function () {
       done()
     })
   })
+
+  it('should allow adding custom html loaders', done => {
+    test({
+      entry: './test/fixtures/markdown.vue',
+      vue: {
+        loaders: {
+          html: 'marked'
+        }
+      }
+    }, (window, module) => {
+      var vnode = mockRender(module, {
+        msg: 'hi'
+      })
+      // <h2 id="-msg-">{{msg}}</h2>
+      expect(vnode.tag).to.equal('h2')
+      expect(vnode.data.attrs.id).to.equal('-msg-')
+      expect(vnode.children[0]).to.equal('hi')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This enables, for example, using a markdown loader via <template lang="md"> in a .vue file.  Without this tweak, the webpack config has to specify both the loader that converts the markdown (e.g.) to HTML **and** template-compiler to compile it.  That, however doesn't fully work because the webpack config can't know the moduleId generated by lib/loader.js and pass it in via the `id` parameter, so scoped styles won't work.