### PR TITLE
fix cannot set css modules to vue instance

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -338,8 +338,15 @@ module.exports = function (content) {
         '    hotAPI.createRecord("' + moduleId + '", Component.options)\n' +
         '  } else {\n' +
         // update
+        '    if (module.hot.data.cssModules && JSON.stringify(module.hot.data.cssModules) !== JSON.stringify(cssModules)) {\n' +
+        '      delete Component.options._Ctor\n' +
+        '    }\n' +
         '    hotAPI.reload("' + moduleId + '", Component.options)\n' +
         '  }\n' +
+        // save cssModules
+        '  module.hot.dispose(function (data) {\n' +
+        '    data.cssModules = cssModules\n' +
+        '  })\n' +
         '})()}\n'
     }
     // final export


### PR DESCRIPTION
Reference (Reproduction repo too): #592 

In css modules, When we change styles, these styles can not set to Vue Instance due to cache of Vue Constructor.
I fixed this issue with using HMR API.