### PR TITLE
Bugfix/8.x webpack2

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -145,7 +145,7 @@ module.exports = function (content) {
           return defaultLoaders.html + '!' + rewriter + templateLoader + '?raw&engine=' + lang + '!'
         case 'style':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
-          return loader + '!' + rewriter + lang + '!'
+          return loader + '!' + rewriter + lang + '-loader' + '!'
         case 'script':
           return injectString + lang + '!'
       }

--- a/test/test.js
+++ b/test/test.js
@@ -306,7 +306,7 @@ describe('vue-loader', function () {
 
       // get local class name
       var className = module.computed.style().red
-      expect(className).to.match(/^_/)
+      expect(className).to.match(/_/)
 
       // class name in style
       var style = [].slice.call(window.document.querySelectorAll('style')).map(function (style) {
@@ -323,7 +323,7 @@ describe('vue-loader', function () {
 
       // default module + pre-processor + scoped
       var anotherClassName = module.computed.$style().red
-      expect(anotherClassName).to.match(/^_/).and.not.equal(className)
+      expect(anotherClassName).to.match(/_/).and.not.equal(className)
       var id = '_v-' + hash(require.resolve('./fixtures/css-modules.vue'))
       expect(style).to.contain('.' + anotherClassName + '[' + id + ']')
 


### PR DESCRIPTION
解决 style 中指定 lang 兼容 webpack2 的问题

webpack2 配置下，制定 style 的 lang 属性，打包发生异常，异常信息如下：

```
> v-admin-framework@1.0.0 dev D:\workspace\work\water\v-admin-framework
> node demo/server.js

Server listening on http://127.0.0.1:9000, Ctrl+C to stop
D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\loadLoader.js:35
                        throw new Error("Module '" + loader.path + "' is not a loader (must have normal or pitch function)");
                        ^

Error: Module 'D:\workspace\work\water\v-admin-framework\node_modules\less\index.js' is not a loader (must have normal or pitch function)
    at loadLoader (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\loadLoader.js:35:10)
    at iteratePitchingLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:169:2)
    at iteratePitchingLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:165:10)
    at D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:173:18
    at loadLoader (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\loadLoader.js:36:3)
    at iteratePitchingLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:169:2)
    at iteratePitchingLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:165:10)
    at D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:173:18
    at loadLoader (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\loadLoader.js:36:3)
    at iteratePitchingLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:169:2)
    at runLoaders (D:\workspace\work\water\v-admin-framework\node_modules\loader-runner\lib\LoaderRunner.js:362:2)
    at NormalModule.doBuild (D:\workspace\work\water\v-admin-framework\node_modules\webpack\lib\NormalModule.js:129:2)
    at NormalModule.build (D:\workspace\work\water\v-admin-framework\node_modules\webpack\lib\NormalModule.js:180:15)
    at Compilation.buildModule (D:\workspace\work\water\v-admin-framework\node_modules\webpack\lib\Compilation.js:142:10)
    at factoryCallback (D:\workspace\work\water\v-admin-framework\node_modules\webpack\lib\Compilation.js:324:11)
    at D:\workspace\work\water\v-admin-framework\node_modules\webpack\lib\NormalModuleFactory.js:242:4
```

测试模板：

```vue
<template>
    <div class="layout">
        <!--
            // something
        -->
    </div>
</template>

<style lang="less" scoped>
  .layout {
    background: #f5f7f9;
    position: relative;
    min-width: 920px;
  }
</style>
```

通过指定 lang 为 `less-loader` 可以解决问题，但是这样处理看上去很别扭。
