### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postcss-load-config": "^1.1.0",
     "postcss-selector-parser": "^2.0.0",
     "source-map": "^0.5.6",
-    "vue-hot-reload-api": "^2.0.1",
+    "vue-hot-reload-api": "^2.0.11",
     "vue-style-loader": "^2.0.0",
     "vue-template-es2015-compiler": "^1.2.2"
   },


### PR DESCRIPTION
When using yarn to install dependencies, yarn will lock the vue-hot-reload-api version to 2.0.1.
After update vue to 2.2.1...

![image](https://cloud.githubusercontent.com/assets/9346008/23359613/fd282f4e-fd21-11e6-8ee8-eb585cac94fc.png)

So I updated the vue-loader dependencies ,run the test, and made this pr.