### PR TITLE
Update parser's call to parseComponent

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,7 +12,7 @@ module.exports = function (content, filename, needMap) {
   var filenameWithHash = filename + '?' + cacheKey
   var output = cache.get(cacheKey)
   if (output) return output
-  output = compiler.parseComponent(content, { pad: true })
+  output = compiler.parseComponent(content, { pad: 'line' })
   if (needMap) {
     if (output.script && !output.script.src) {
       output.script.map = generateSourceMap(


### PR DESCRIPTION
The pad option now accepts 'line' or 'space' as padding options.

Depends on vuejs/vue#5059, although the original check for `pad` is a truthy one, so this PR could be merged before that one with no trouble.