### PR TITLE
when mismatch version, it is better to fail the loader and webpack show error code

### DIFF
--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -58,6 +58,13 @@ module.exports = function (html) {
       options.transformToRequire
     )
   }
+  
+  var compilerVersion = require('vue-template-compiler/package.json').version
+  var vueVersion = require('vue').version
+
+  if(vueVersion !== compilerVersion){
+    this.emitError(`vue version ${vueVersion} mismatch vue-template-compiler version ${compilerVersion}`)
+  }
 
   var compiled = compiler.compile(html, Object.assign({
     preserveWhitespace: options.preserveWhitespace

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -58,11 +58,10 @@ module.exports = function (html) {
       options.transformToRequire
     )
   }
-  
   var compilerVersion = require('vue-template-compiler/package.json').version
   var vueVersion = require('vue').version
 
-  if(vueVersion !== compilerVersion){
+  if (vueVersion !== compilerVersion) {
     this.emitError(`vue version ${vueVersion} mismatch vue-template-compiler version ${compilerVersion}`)
   }
 

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -58,11 +58,19 @@ module.exports = function (html) {
       options.transformToRequire
     )
   }
-  var compilerVersion = require('vue-template-compiler/package.json').version
-  var vueVersion = require('vue').version
 
-  if (vueVersion !== compilerVersion) {
-    this.emitError(`vue version ${vueVersion} mismatch vue-template-compiler version ${compilerVersion}`)
+  // when vue and vue-template-compiler mismatch version, then fail the vue-loader
+  var vueTemplateCompiler = require('vue-template-compiler/package.json')
+  var vueVersion = require('vue/package.json').version
+  if (vueVersion !== vueTemplateCompiler.version) {
+    this.emitError(`\n
+        Vue packages version mismatch:
+        -vue@${vueVersion}
+        -${vueTemplateCompiler.name}@${vueTemplateCompiler.version}
+        This may cause things to work incorrectly. Make sure to use the same version for both.
+        If you are using vue-loader@>=10.0, simply update ${vueTemplateCompiler.name}.
+        If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump ${vueTemplateCompiler.version} to the latest.\n
+    `)
   }
 
   var compiled = compiler.compile(html, Object.assign({


### PR DESCRIPTION
instead of checking version in vue-template-compiler runtime, check the version in vue-loader.
when mismatch version, the loader will fail and the webpack will return the error code.