### PR TITLE
fix parse cssModules loader query

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -145,7 +145,7 @@ module.exports = function (content) {
     return loader.replace(/((?:^|!)css(?:-loader)?)(\?[^!]*)?/, function (m, $1, $2) {
       // $1: !css-loader
       // $2: ?a=b
-      var query = loaderUtils.getOptions($2 || {}) || {}
+      var query = loaderUtils.parseQuery($2 || '?')
       Object.assign(query, OPTIONS, option, DEFAULT_OPTIONS)
       if (index !== -1) {
         // Note:


### PR DESCRIPTION
Hi,
I think it should use `loaderUtils.parseQuery` to parse the result from regular expression.
Otherwise we can't get css-loader' query such like `...!css-loader?{"minimize":true}...` for css-module.
The last change RP: https://github.com/vuejs/vue-loader/commit/1d63e9ec610490767b447cee5cf53e00faf905fa
Thanks