### PR TITLE
Change let to var

### DIFF
--- a/lib/style-compiler/load-postcss-config.js
+++ b/lib/style-compiler/load-postcss-config.js
@@ -1,6 +1,6 @@
 var load = require('postcss-load-config')
 
-let loaded
+var loaded
 
 function isObject (val) {
   return val && typeof val === 'object'


### PR DESCRIPTION
Hey guys,

I found this small issue today after refreshing my node modules and pulling in a new version of vue-loader. I'm using Node v4.7.3 and it was throwing this error whilst compiling style blocks:

`SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`

So, this tiny change is how I fixed it...pretty sure it's not going to break anything!