### PR TITLE
Add note about OccurrenceOrderPlugin

### DIFF
--- a/docs/en/workflow/production.md
+++ b/docs/en/workflow/production.md
@@ -24,7 +24,7 @@ module.exports = {
         warnings: false
       }
     }),
-    // optimize module ids by occurrence count
+    // Webpack 1 only - optimize module ids by occurrence count
     new webpack.optimize.OccurrenceOrderPlugin()
   ]
 }


### PR DESCRIPTION
The OccurrenceOrderPlugin enabled by default in Webpack 2

P.S.: Or maybe better to remove this from example?