### PR TITLE
fix: extractCSS should only be applied to styles

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -213,7 +213,7 @@ module.exports = function (content) {
       }
     }
 
-    var loader = options.extractCSS
+    var loader = options.extractCSS && type === 'styles'
       ? loaders[lang] || getCSSExtractLoader(lang)
       : loaders[lang]
 

--- a/test/test.js
+++ b/test/test.js
@@ -166,6 +166,32 @@ describe('vue-loader', function () {
     })
   })
 
+  it('pre-processors with extract css', done => {
+    test({
+      entry: './test/fixtures/pre.vue',
+      vue: {
+        extractCSS: true
+      },
+      plugins: [
+        new ExtractTextPlugin('test.output.css')
+      ]
+    }, (window, module) => {
+      var vnode = mockRender(module)
+
+      expect(vnode.children[0].tag).to.equal('h1')
+      expect(vnode.children[1].tag).to.equal('comp-a')
+      expect(vnode.children[2].tag).to.equal('comp-b')
+
+      expect(module.data().msg).to.contain('Hello from coffee!')
+
+      var css = mfs.readFileSync('/test.output.css').toString()
+      css = normalizeNewline(css)
+      expect(css).to.contain('body {\n  font: 100% Helvetica, sans-serif;\n  color: #999;\n}')
+
+      done()
+    })
+  })
+
   it('scoped style', done => {
     test({
       entry: './test/fixtures/scoped-css.vue',


### PR DESCRIPTION
fix https://github.com/Microsoft/TypeScript-Vue-Starter/pull/3

 If `extractCSS` is true, vue-loader will consult text extractor if loaders[lang] is not explicitly configured. This causes pug-loader and ts-loader malfunctions.

This PR makes extractCSS is only applied to styles.