### PR TITLE
"npm install -g" requires "root" privileges on Linux

### DIFF
--- a/docs/en/start/setup.md
+++ b/docs/en/start/setup.md
@@ -5,7 +5,7 @@
 It's recommended to scaffold a project using `vue-loader` with `vue-cli`:
 
 ``` bash
-npm install -g vue-cli
+sudo npm install -g vue-cli
 vue init webpack-simple hello-vue
 cd hello-vue
 npm install


### PR DESCRIPTION
Tested on Linux. Alternatively, we can install without the "-g" option which works only for the current user, in which case we need to create a symlink manually:
```bash
ln -s ~/node_modules/vue-cli/bin/vue ~/bin/vue
```