### PR TITLE
Allows babel to run after typescript

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -19,7 +19,7 @@ var styleLoaderPath = normalize.dep('vue-style-loader')
 var hotReloadAPIPath = normalize.dep('vue-hot-reload-api')
 
 // check whether default js loader exists
-var hasTs    = !!tryRequire('ts-loader')
+var hasTs = !!tryRequire('ts-loader')
 var hasBabel = !!tryRequire('babel-loader')
 var hasBuble = !!tryRequire('buble-loader')
 
@@ -89,7 +89,7 @@ module.exports = function (content) {
       : styleLoaderPath + '!' + 'css-loader' + cssLoaderOptions,
     js: hasBuble ? ('buble-loader' + bubleOptions) : hasBabel ? 'babel-loader' : ''
   }
-  
+
   if (hasTs) {
     defaultLoaders.ts = defaultLoaders.js
                       ? defaultLoaders.js + '!ts-loader'

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -19,6 +19,7 @@ var styleLoaderPath = normalize.dep('vue-style-loader')
 var hotReloadAPIPath = normalize.dep('vue-hot-reload-api')
 
 // check whether default js loader exists
+var hasTs    = !!tryRequire('ts-loader')
 var hasBabel = !!tryRequire('babel-loader')
 var hasBuble = !!tryRequire('buble-loader')
 
@@ -87,6 +88,12 @@ module.exports = function (content) {
       ? getCSSExtractLoader()
       : styleLoaderPath + '!' + 'css-loader' + cssLoaderOptions,
     js: hasBuble ? ('buble-loader' + bubleOptions) : hasBabel ? 'babel-loader' : ''
+  }
+  
+  if (hasTs) {
+    defaultLoaders.ts = defaultLoaders.js
+                      ? defaultLoaders.js + '!ts-loader'
+                      : 'ts-loader'
   }
 
   // check if there are custom loaders specified via


### PR DESCRIPTION
I'm not so experienced with making PRs so please let me know if I'm doing it wrong.

Anyhow, I'm using VueJS with typescript in my own projects and I didn't manage to setup my webpack config in such a way that it would also run babel on my vue-files after running typescript. Until I started messing around in the vue-loader itself and figured out that the piece of code that I'm submitting in this PR did work.

Now you may be thinking "but dude, if you can write `ts: 'babel-loader!ts-loader'` in vue-loader then you can also write that in your own config". But no, for some reason webpack then says it can't resolve `'babel-loader!ts-loader'`, even though it can resolve it when I put it in vue-loader.

So yeah, I hope you're willing to accept this PR, so that I don't have to make my project depend on my own fork to make it work. Because that would mean that I'd need to maintain my own fork as well...