### PR TITLE
Don't mutate this.options (fixes #824)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -49,7 +49,7 @@ module.exports = function (content) {
 
   var loaderContext = this
   var query = loaderUtils.getOptions(this) || {}
-  var options = this.options.__vueOptions__ = Object.assign({}, this.options.vue, this.vue, query)
+  var options = Object.assign({}, this.options.vue, this.vue, query)
   var rawRequest = getRawRequest(this, options.excludedPreLoaders)
 
   var filePath = this.resourcePath
@@ -70,16 +70,21 @@ module.exports = function (content) {
     ? '?' + JSON.stringify(options.buble)
     : ''
 
-  var templateCompilerOptions = '?' + JSON.stringify({
-    id: moduleId,
-    transformToRequire: options.transformToRequire,
-    preserveWhitespace: options.preserveWhitespace,
-    buble: options.buble,
-    // only pass compilerModules if it's a path string
-    compilerModules: typeof options.compilerModules === 'string'
-      ? options.compilerModules
-      : undefined
-  })
+  var templateCompilerOptions = '?' + JSON.stringify(
+    Object.assign({},
+      query,
+      {
+        id: moduleId,
+        transformToRequire: options.transformToRequire,
+        preserveWhitespace: options.preserveWhitespace,
+        buble: options.buble,
+        // only pass compilerModules if it's a path string
+        compilerModules: typeof options.compilerModules === 'string'
+          ? options.compilerModules
+          : undefined
+      }
+    )
+  )
 
   var defaultLoaders = {
     html: templateCompilerPath + templateCompilerOptions,
@@ -196,13 +201,18 @@ module.exports = function (content) {
     var styleCompiler = ''
     if (type === 'styles') {
       // style compiler that needs to be applied for all styles
-      styleCompiler = styleCompilerPath + '?' + JSON.stringify({
-        // a marker for vue-style-loader to know that this is an import from a vue file
-        vue: true,
-        id: moduleId,
-        scoped: !!scoped,
-        hasInlineConfig: !!query.postcss
-      }) + '!'
+      styleCompiler = styleCompilerPath + '?' + JSON.stringify(
+        Object.assign({},
+          query,
+          {
+            // a marker for vue-style-loader to know that this is an import from a vue file
+            vue: true,
+            id: moduleId,
+            scoped: !!scoped,
+            hasInlineConfig: !!query.postcss
+          }
+        )
+      ) + '!'
       // normalize scss/sass if no specific loaders have been provided
       if (!loaders[lang]) {
         if (lang === 'sass') {

--- a/lib/style-compiler/index.js
+++ b/lib/style-compiler/index.js
@@ -9,10 +9,10 @@ module.exports = function (css, map) {
   this.cacheable()
   var cb = this.async()
 
-  var query = loaderUtils.getOptions(this) || {}
-  var vueOptions = this.options.__vueOptions__
+  var query = Object.assign({}, loaderUtils.getOptions(this), this.options.vue, this.vue)
 
-  if (!vueOptions) {
+  // Slightly messy check for HappyPack as we can't use this.__vueoptions__ anymore
+  if (this._compiler.constructor.name === 'HappyFakeCompiler') {
     if (query.hasInlineConfig) {
       this.emitError(
         `\n  [vue-loader] It seems you are using HappyPack with inline postcss ` +
@@ -22,10 +22,9 @@ module.exports = function (css, map) {
         `\n  See http://vue-loader.vuejs.org/en/features/postcss.html#using-a-config-file for more details.\n`
       )
     }
-    vueOptions = Object.assign({}, this.options.vue, this.vue)
   }
 
-  loadPostcssConfig(this, vueOptions.postcss).then(config => {
+  loadPostcssConfig(this, query.postcss).then(config => {
     var plugins = [trim].concat(config.plugins)
     var options = Object.assign({
       to: this.resourcePath,
@@ -42,7 +41,7 @@ module.exports = function (css, map) {
     if (
       this.sourceMap &&
       !this.minimize &&
-      vueOptions.cssSourceMap !== false &&
+      query.cssSourceMap !== false &&
       process.env.NODE_ENV !== 'production' &&
       !options.map
     ) {

--- a/lib/style-compiler/index.js
+++ b/lib/style-compiler/index.js
@@ -11,7 +11,7 @@ module.exports = function (css, map) {
 
   var query = Object.assign({}, loaderUtils.getOptions(this), this.options.vue, this.vue)
 
-  // Slightly messy check for HappyPack as we can't use this.__vueoptions__ anymore
+  // Slightly messy check for HappyPack as we can't use this.options.__vueoptions__ anymore
   if (this._compiler.constructor.name === 'HappyFakeCompiler') {
     if (query.hasInlineConfig) {
       this.emitError(

--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -10,11 +10,10 @@ module.exports = function (html) {
   this.cacheable()
   var isServer = this.target === 'node'
   var isProduction = this.minimize || process.env.NODE_ENV === 'production'
-  var vueOptions = this.options.__vueOptions__ || {}
-  var options = loaderUtils.getOptions(this) || {}
+  var options = Object.assign({}, loaderUtils.getOptions(this), this.options.vue, this.vue)
 
   var defaultModules = [transformRequire(options.transformToRequire)]
-  var userModules = vueOptions.compilerModules || options.compilerModules
+  var userModules = options.compilerModules
   // for HappyPack cross-process use cases
   if (typeof userModules === 'string') {
     userModules = require(userModules)

--- a/lib/template-compiler/preprocessor.js
+++ b/lib/template-compiler/preprocessor.js
@@ -11,7 +11,7 @@ module.exports = function (content) {
 
   // this is never documented and should be deprecated
   // but we'll keep it so we don't break stuff
-  var vue = this.options.__vueOptions__
+  var vue = Object.assign({}, this.options.vue, this.vue)
   if (vue && vue.template) {
     for (var key in vue.template) {
       opt[key] = vue.template[key]


### PR DESCRIPTION
As mentioned in #824, modifying the options object causes webpack to error if you run it more than once with the same config.

This PR stops `lib/loader.js` from setting `this.options.__vueoptions__` and stops any other file from relying on it. I'm not sure if any other loader relies on this key, anything that does would be broken by this PR.

I've also had to rely on checking `this._compiler.constructor.name` in `lib/style-compiler/index.js` to check for happypack, I'm pretty sure that's what the original line was doing? It doesn't feel good but it will work. I don't have any experience with happypack, so I can't confirm if this makes a difference.

It passes all tests, I didn't think the changes needed a new test but I can write one if needed.
Hopefully I havn't missed anything!