### PR TITLE
Update webpack url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vue-loader [![Build Status](https://circleci.com/gh/vuejs/vue-loader/tree/master.svg?style=shield)](https://circleci.com/gh/vuejs/vue-loader/tree/master) [![Windows Build status](https://ci.appveyor.com/api/projects/status/8cdonrkbg6m4k1tm/branch/master?svg=true)](https://ci.appveyor.com/project/yyx990803/vue-loader/branch/master) [![npm package](https://img.shields.io/npm/v/vue-loader.svg?maxAge=2592000)](https://www.npmjs.com/package/vue-loader)
 
-> Vue.js component loader for [Webpack](http://webpack.github.io).
+> Vue.js component loader for [Webpack](https://webpack.js.org/).
 
 **NOTE: the master branch (9.0+) only works with Vue 2.x. For usage with Vue 1.x, see the [8.x branch](https://github.com/vuejs/vue-loader/tree/8.x).**
 


### PR DESCRIPTION
The link now points to webpack 2 instead of webpack 1

Fixes #829