### PR TITLE
Update scoped-css.md with info about deep selectors

### DIFF
--- a/docs/en/features/scoped-css.md
+++ b/docs/en/features/scoped-css.md
@@ -49,3 +49,19 @@ Into the following:
 4. **Scoped styles do not eliminate the need for classes**. Due to the way browsers render various CSS selectors, `p { color: red }` will be many times slower when scoped (i.e. when combined with an attribute selector). If you use classes or ids instead, such as in `.example { color: red }`, then you virtually eliminate that performance hit. [Here's a playground](http://stevesouders.com/efws/css-selectors/csscreate.php) where you can test the differences yourself.
 
 5. **Be careful with descendant selectors in recursive components!** For a CSS rule with the selector `.a .b`, if the element that matches `.a` contains a recursive child component, then all `.b` in that child component will be matched by the rule.
+
+6. If you need nested selectors in `scoped` styles, you will have to use `>>>` operator for CSS and `/deep/` for `scss`:
+
+    ``` html
+    <style scoped>
+    .a >>> .b {
+    
+    }
+    </style>
+    
+    <style lang="scss" scoped>
+    .a /deep/ .b {
+    
+    }
+    </style>
+    ```


### PR DESCRIPTION
In 12.1 version deep selectors (`>>>` and `/deep/`) have been introduced but there is no info about that in the documentation.