### PR TITLE
Use phantomjs-prebuilt instead of phantomjs

### DIFF
--- a/docs/en/workflow/testing.md
+++ b/docs/en/workflow/testing.md
@@ -10,7 +10,7 @@ Karma is a test runner that launches browsers and runs your tests for you. You c
 npm install\
   karma karma-webpack\
   karma-jasmine jasmine-core\
-  karma-phantomjs-launcher phantomjs\
+  karma-phantomjs-launcher phantomjs-prebuilt\
   --save-dev
 ```
 


### PR DESCRIPTION
From [phantomjs npm](https://www.npmjs.com/package/phantomjs):

> DEPRECATED
> Pre-2.0, this package was published to NPM as phantomjs. We changed the name to phantomjs prebuilt at the request of PhantomJS team.
> 
> Please update your package references from phantomjs to phantomjs-prebuilt