### PR TITLE
Support webpack 3 module concatenation by using `import`s instead of `require`s.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -581,7 +581,7 @@ module.exports = function (content) {
     }
     // final export
     if (options.esModule) {
-      output += '\nexports.__esModule = true;\nexports["default"] = Component.exports\n'
+      output += '\nexport default Component.exports\n'
     } else {
       output += '\nmodule.exports = Component.exports\n'
     }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -107,6 +107,10 @@ module.exports = function (content) {
     ')'
   }
 
+  function getImport (type, part, index, scoped) {
+    return 'import __vue_' + type + '__ from ' + getRequireString(type, part, index, scoped)
+  }
+
   function getRequireString (type, part, index, scoped) {
     return loaderUtils.stringifyRequest(loaderContext,
       // disable all configuration loaders
@@ -124,6 +128,10 @@ module.exports = function (content) {
     return 'require(' +
       getRequireForImportString(type, impt, scoped) +
     ')'
+  }
+
+  function getImportForImport (type, impt, scoped) {
+    return 'import __vue_' + type + '__ from ' + getRequireForImportString(type, impt, scoped)
   }
 
   function getRequireForImportString (type, impt, scoped) {
@@ -420,52 +428,74 @@ module.exports = function (content) {
   //   scopeId,
   //   moduleIdentifier (server only)
   // )
-  output += 'var Component = require(' +
-    loaderUtils.stringifyRequest(loaderContext, '!' + componentNormalizerPath) +
-  ')(\n'
+  if (options.esModule) {
+    output += 'import normalizeComponent from ' +
+      loaderUtils.stringifyRequest(loaderContext, '!' + componentNormalizerPath) +
+    '\n'
+  } else {
+    output += 'var normalizeComponent = require(' +
+      loaderUtils.stringifyRequest(loaderContext, '!' + componentNormalizerPath) +
+    ')\n'
+  }
 
   // <script>
-  output += '  /* script */\n  '
+  output += '/* script */\n'
   var script = parts.script
   if (script) {
-    output += script.src
-      ? getRequireForImport('script', script)
-      : getRequire('script', script)
+    if (options.esModule) {
+      output += script.src
+        ? getImportForImport('script', script)
+        : getImport('script', script) + '\n'
+    } else {
+      output += 'var __vue_script__ = ' + (script.src
+        ? getRequireForImport('script', script)
+        : getRequire('script', script)) + '\n'
+    }
     // inject loader interop
     if (query.inject) {
-      output += '(injections)'
+      output += '__vue_script__ = __vue_script__(injections)\n'
     }
   } else {
-    output += 'null'
+    output += 'var __vue_script__ = null\n'
   }
-  output += ',\n'
 
   // <template>
-  output += '  /* template */\n  '
+  output += '/* template */\n'
   var template = parts.template
   if (template) {
-    output += template.src
-      ? getRequireForImport('template', template)
-      : getRequire('template', template)
+    if (options.esModule) {
+      output += (template.src
+        ? getImportForImport('template', template)
+        : getImport('template', template)) + '\n'
+    } else {
+      output += 'var __vue_template__ = ' + (template.src
+        ? getRequireForImport('template', template)
+        : getRequire('template', template)) + '\n'
+    }
   } else {
-    output += 'null'
+    output += 'var __vue_template__ = null\n'
   }
-  output += ',\n'
 
   // style
-  output += '  /* styles */\n  '
-  output += (parts.styles.length ? 'injectStyle' : 'null') + ',\n'
+  output += '/* styles */\n'
+  output += 'var __vue_styles__ = ' + (parts.styles.length ? 'injectStyle' : 'null') + '\n'
 
   // scopeId
-  output += '  /* scopeId */\n  '
-  output += (hasScoped ? JSON.stringify(moduleId) : 'null') + ',\n'
+  output += '/* scopeId */\n'
+  output += 'var __vue_scopeId__ = ' + (hasScoped ? JSON.stringify(moduleId) : 'null') + '\n'
 
   // moduleIdentifier (server only)
-  output += '  /* moduleIdentifier (server only) */\n  '
-  output += (isServer ? JSON.stringify(hash(this.request)) : 'null') + '\n'
+  output += '/* moduleIdentifier (server only) */\n'
+  output += 'var __vue_module_identifier__ = ' + (isServer ? JSON.stringify(hash(this.request)) : 'null') + '\n'
 
   // close normalizeComponent call
-  output += ')\n'
+  output += 'var Component = normalizeComponent(\n' +
+    '  __vue_script__,\n' +
+    '  __vue_template__,\n' +
+    '  __vue_styles__,\n' +
+    '  __vue_scopeId__,\n' +
+    '  __vue_module_identifier__\n' +
+    ')\n'
 
   // development-only code
   if (!isProduction) {


### PR DESCRIPTION
A very basic transformation from `require` to `import`, more work & help needed.

1. The use of `config.esModule`
I'm currently using this existing config as option for using `imports` instead of `require`s. Since it's undocumented, I'm not sure if this is a breaking change/it's suitable for this feature.

2. To-do: 
- [ ] Tests (I'm not sure how module concatenation can be tested here...)
- [ ] Documentation

3. Mysterious webpack warnings that doesn't seem to be related to vue-loader
```
  [12] ./node_modules/vue/dist/vue.runtime.esm.js 187 kB {15} {16} [built]
       ModuleConcatenation (inner): dependency variables are used (i. e. ProvidePlugin)
```

4. Unpassed test: `vue-loader expose filename`, this one's failing on master too, probably not related to this PR
