### PR TITLE
use chai syntax for mock test example

### DIFF
--- a/docs/en/workflow/testing-with-mocks.md
+++ b/docs/en/workflow/testing-with-mocks.md
@@ -65,6 +65,6 @@ it('should render', () => {
       'test': ExampleWithMocks
     }
   }).$mount()
-  expect(vm.$el.querySelector('.msg').textContent).toBe('Hello from a mocked service!')
+  expect(vm.$el.querySelector('.msg').textContent).to.equal('Hello from a mocked service!')
 })
 ```


### PR DESCRIPTION
since we use mocha&chai in our webpack template, it makes sense that the test examples use that syntax as well.