### PR TITLE
Support postcss.options.plugins being a function

### DIFF
--- a/lib/style-compiler/load-postcss-config.js
+++ b/lib/style-compiler/load-postcss-config.js
@@ -27,7 +27,9 @@ module.exports = function loadPostcssConfig (loaderContext, inlineConfig) {
     if (Array.isArray(inlineConfig)) {
       plugins = inlineConfig
     } else if (isObject(inlineConfig)) {
-      plugins = inlineConfig.plugins || []
+      plugins = (typeof inlineConfig.plugins === 'function')
+        ? inlineConfig.plugins.call(this, this)
+        : inlineConfig.plugins || []
       options = inlineConfig.options || {}
     }
 


### PR DESCRIPTION
We currently support postcss options being a function, but not options.plugins.
This should be mostly harmless -- I wanted to provide a test but we don't currently test support for any postcss plugin, do we?