### PR TITLE
POC - Add cache option for vue-loader, DO NOT MERGE

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,8 @@ var parse = require('./parser')
 var genId = require('./utils/gen-id')
 var querystring = require('querystring')
 var loaderUtils = require('loader-utils')
+var createCache = require('loader-fs-cache')
+var pkg = require('../package.json')
 var normalize = require('./utils/normalize')
 var tryRequire = require('./utils/try-require')
 
@@ -23,6 +25,8 @@ var hasBabel = !!tryRequire('babel-loader')
 var hasBuble = !!tryRequire('buble-loader')
 
 var rewriterInjectRE = /\b(css(?:-loader)?(?:\?[^!]+)?)(?:!|$)/
+
+var cache = createCache('vue-loader')
 
 var defaultLang = {
   template: 'html',
@@ -85,8 +89,6 @@ module.exports = function (content) {
   var bubleOptions = hasBuble && options.buble
     ? '?' + JSON.stringify(options.buble)
     : ''
-
-  var output = ''
   var parts = parse(content, fileName, this.sourceMap)
   var hasScoped = parts.styles.some(function (s) { return s.scoped })
 
@@ -116,267 +118,296 @@ module.exports = function (content) {
   var preLoaders = options.preLoaders || {}
   var postLoaders = options.postLoaders || {}
 
-  var needsHotReload = (
-    !isServer &&
-    !isProduction &&
-    (parts.script || parts.template)
-  )
-
-  if (needsHotReload) {
-    output += 'var disposed = false\n'
-  }
-
-  // add requires for styles
-  var cssModules
-  if (parts.styles.length) {
-    var styleInjectionCode = 'function injectStyle (ssrContext) {\n'
-    if (needsHotReload) {
-      styleInjectionCode += `  if (disposed) return\n`
-    }
-    if (isServer) {
-      styleInjectionCode += `var i\n`
-    }
-    parts.styles.forEach(function (style, i) {
-      // require style
-      var requireString = style.src
-        ? getRequireForImport('styles', style, style.scoped)
-        : getRequire('styles', style, i, style.scoped)
-
-      var hasStyleLoader = requireString.indexOf('style-loader') > -1
-      var hasVueStyleLoader = requireString.indexOf('vue-style-loader') > -1
-      // vue-style-loader exposes inject functions during SSR so they are
-      // always called
-      var invokeStyle = isServer && hasVueStyleLoader
-        ? code => `;(i=${code},i.__inject__&&i.__inject__(ssrContext),i)\n`
-        : code => `  ${code}\n`
-
-      var moduleName = (style.module === true) ? '$style' : style.module
-      // setCssModule
-      if (moduleName) {
-        if (!cssModules) {
-          cssModules = {}
-          if (needsHotReload) {
-            output += `var cssModules = {}\n`
-          }
+  if (options.cache) {
+    var callback = this.async()
+    return cache(
+      {
+        identifier: JSON.stringify({
+          'vue-loader': pkg.version
+        }),
+        options: options,
+        source: content,
+        transform: function () {
+          return generateOutput()
         }
-        if (moduleName in cssModules) {
-          loaderContext.emitError('CSS module name "' + moduleName + '" is not unique!')
-          styleInjectionCode += invokeStyle(requireString)
-        } else {
-          cssModules[moduleName] = true
-
-          // `(vue-)style-loader` exposes the name-to-hash map directly
-          // `css-loader` exposes it in `.locals`
-          // add `.locals` if the user configured to not use style-loader.
-          if (!hasStyleLoader) {
-            requireString += '.locals'
-          }
-
-          if (!needsHotReload) {
-            styleInjectionCode += invokeStyle('this["' + moduleName + '"] = ' + requireString)
-          } else {
-            // handle hot reload for CSS modules.
-            // we store the exported locals in an object and proxy to it by
-            // defining getters inside component instances' lifecycle hook.
-            styleInjectionCode +=
-              invokeStyle(`cssModules["${moduleName}"] = ${requireString}`) +
-              `Object.defineProperty(this, "${moduleName}", { get: function () { return cssModules["${moduleName}"] }})\n`
-
-            var requirePath = getRequireString('styles', style, i, style.scoped)
-            output +=
-              `module.hot && module.hot.accept([${requirePath}], function () {\n` +
-              // 1. check if style has been injected
-              `  var oldLocals = cssModules["${moduleName}"]\n` +
-              `  if (!oldLocals) return\n` +
-              // 2. re-import (side effect: updates the <style>)
-              `  var newLocals = ${requireString}\n` +
-              // 3. compare new and old locals to see if selectors changed
-              `  if (JSON.stringify(newLocals) === JSON.stringify(oldLocals)) return\n` +
-              // 4. locals changed. Update and force re-render.
-              `  cssModules["${moduleName}"] = newLocals\n` +
-              `  require("${hotReloadAPIPath}").rerender("${moduleId}")\n` +
-              `})\n`
-          }
-        }
-      } else {
-        styleInjectionCode += invokeStyle(requireString)
-      }
-    })
-    styleInjectionCode += '}\n'
-    output += styleInjectionCode
-  }
-
-  // we require the component normalizer function, and call it like so:
-  // normalizeComponent(
-  //   scriptExports,
-  //   compiledTemplate,
-  //   injectStyles,
-  //   scopeId,
-  //   moduleIdentifier (server only)
-  // )
-  output += 'var normalizeComponent = require(' +
-    loaderUtils.stringifyRequest(loaderContext, '!' + componentNormalizerPath) +
-  ')\n'
-
-  // <script>
-  output += '/* script */\n'
-  var script = parts.script
-  if (script) {
-    if (options.esModule) {
-      output += script.src
-        ? getImportForImport('script', script)
-        : getImport('script', script) + '\n'
-    } else {
-      output += 'var __vue_script__ = ' + (script.src
-        ? getRequireForImport('script', script)
-        : getRequire('script', script)) + '\n'
-    }
-    // inject loader interop
-    if (query.inject) {
-      output += '__vue_script__ = __vue_script__(injections)\n'
-    }
-  } else {
-    output += 'var __vue_script__ = null\n'
-  }
-
-  // <template>
-  output += '/* template */\n'
-  var template = parts.template
-  if (template) {
-    if (options.esModule) {
-      output += (template.src
-        ? getImportForImport('template', template)
-        : getImport('template', template)) + '\n'
-    } else {
-      output += 'var __vue_template__ = ' + (template.src
-        ? getRequireForImport('template', template)
-        : getRequire('template', template)) + '\n'
-    }
-  } else {
-    output += 'var __vue_template__ = null\n'
-  }
-
-  // style
-  output += '/* styles */\n'
-  output += 'var __vue_styles__ = ' + (parts.styles.length ? 'injectStyle' : 'null') + '\n'
-
-  // scopeId
-  output += '/* scopeId */\n'
-  output += 'var __vue_scopeId__ = ' + (hasScoped ? JSON.stringify(moduleId) : 'null') + '\n'
-
-  // moduleIdentifier (server only)
-  output += '/* moduleIdentifier (server only) */\n'
-  output += 'var __vue_module_identifier__ = ' + (isServer ? JSON.stringify(hash(this.request)) : 'null') + '\n'
-
-  // close normalizeComponent call
-  output += 'var Component = normalizeComponent(\n' +
-    '  __vue_script__,\n' +
-    '  __vue_template__,\n' +
-    '  __vue_styles__,\n' +
-    '  __vue_scopeId__,\n' +
-    '  __vue_module_identifier__\n' +
-    ')\n'
-
-  // development-only code
-  if (!isProduction) {
-    // add filename in dev
-    output += 'Component.options.__file = ' + JSON.stringify(shortFilePath) + '\n'
-    // check named exports
-    output +=
-      'if (Component.esModule && Object.keys(Component.esModule).some(function (key) {' +
-        'return key !== "default" && key.substr(0, 2) !== "__"' +
-      '})) {' +
-        'console.error("named exports are not supported in *.vue files.")' +
-      '}\n'
-    // check functional components used with templates
-    if (template) {
-      output +=
-        'if (Component.options.functional) {' +
-          'console.error("' +
-          '[vue-loader] ' + fileName + ': functional components are not ' +
-          'supported with templates, they should use render functions.' +
-        '")}\n'
-    }
-  }
-
-  // add requires for customBlocks
-  if (parts.customBlocks && parts.customBlocks.length) {
-    var addedPrefix = false
-
-    parts.customBlocks.forEach(function (customBlock, i) {
-      if (loaders[customBlock.type]) {
-        // require customBlock
-        customBlock.src = customBlock.attrs.src
-        var requireString = customBlock.src
-          ? getRequireForImport(customBlock.type, customBlock)
-          : getRequire(customBlock.type, customBlock, i)
-
-        if (!addedPrefix) {
-          output += '\n/* customBlocks */\n'
-          addedPrefix = true
+      },
+      function (err, res) {
+        if (err) {
+          return callback(err)
         }
 
-        output +=
-          'var customBlock = ' + requireString + '\n' +
-          'if (typeof customBlock === "function") {' +
-            'customBlock(Component)' +
-          '}\n'
+        return callback(null, res)
       }
-    })
-
-    output += '\n'
+    )
   }
 
-  if (!query.inject) {
-    // hot reload
-    if (needsHotReload) {
-      output +=
-        '\n/* hot reload */\n' +
-        'if (module.hot) {(function () {\n' +
-        '  var hotAPI = require("' + hotReloadAPIPath + '")\n' +
-        '  hotAPI.install(require("vue"), false)\n' +
-        '  if (!hotAPI.compatible) return\n' +
-        '  module.hot.accept()\n' +
-        '  if (!module.hot.data) {\n' +
-        // initial insert
-        '    hotAPI.createRecord("' + moduleId + '", Component.options)\n' +
-        '  } else {\n'
-      // update
-      if (cssModules) {
-        output +=
-        '    if (module.hot.data.cssModules && Object.keys(module.hot.data.cssModules) !== Object.keys(cssModules)) {\n' +
-        '      delete Component.options._Ctor\n' +
-        '    }\n'
-      }
-      output +=
-        '    hotAPI.reload("' + moduleId + '", Component.options)\n' +
-        '  }\n'
-      // dispose
-      output +=
-        '  module.hot.dispose(function (data) {\n' +
-        (cssModules ? '    data.cssModules = cssModules\n' : '') +
-        '    disposed = true\n' +
-        '  })\n'
-      output += '})()}\n'
-    }
-    // final export
-    if (options.esModule) {
-      output += '\nexport default Component.exports\n'
-    } else {
-      output += '\nmodule.exports = Component.exports\n'
-    }
-  } else {
-    // inject-loader support
-    output =
-      '\n/* dependency injection */\n' +
-      'module.exports = function (injections) {\n' + output + '\n' +
-      '\nreturn Component.exports\n}'
-  }
-
-  // done
-  return output
+  return generateOutput()
 
   // --- helpers ---
+
+  function generateOutput () {
+    var output = ''
+
+    var needsHotReload = (
+      !isServer &&
+      !isProduction &&
+      (parts.script || parts.template)
+    )
+
+    if (needsHotReload) {
+      output += 'var disposed = false\n'
+    }
+
+    // add requires for styles
+    var cssModules
+    if (parts.styles.length) {
+      var styleInjectionCode = 'function injectStyle (ssrContext) {\n'
+      if (needsHotReload) {
+        styleInjectionCode += `  if (disposed) return\n`
+      }
+      if (isServer) {
+        styleInjectionCode += `var i\n`
+      }
+      parts.styles.forEach(function (style, i) {
+        // require style
+        var requireString = style.src
+          ? getRequireForImport('styles', style, style.scoped)
+          : getRequire('styles', style, i, style.scoped)
+
+        var hasStyleLoader = requireString.indexOf('style-loader') > -1
+        var hasVueStyleLoader = requireString.indexOf('vue-style-loader') > -1
+        // vue-style-loader exposes inject functions during SSR so they are
+        // always called
+        var invokeStyle = isServer && hasVueStyleLoader
+          ? code => `;(i=${code},i.__inject__&&i.__inject__(ssrContext),i)\n`
+          : code => `  ${code}\n`
+
+        var moduleName = (style.module === true) ? '$style' : style.module
+        // setCssModule
+        if (moduleName) {
+          if (!cssModules) {
+            cssModules = {}
+            if (needsHotReload) {
+              output += `var cssModules = {}\n`
+            }
+          }
+          if (moduleName in cssModules) {
+            loaderContext.emitError('CSS module name "' + moduleName + '" is not unique!')
+            styleInjectionCode += invokeStyle(requireString)
+          } else {
+            cssModules[moduleName] = true
+
+            // `(vue-)style-loader` exposes the name-to-hash map directly
+            // `css-loader` exposes it in `.locals`
+            // add `.locals` if the user configured to not use style-loader.
+            if (!hasStyleLoader) {
+              requireString += '.locals'
+            }
+
+            if (!needsHotReload) {
+              styleInjectionCode += invokeStyle('this["' + moduleName + '"] = ' + requireString)
+            } else {
+              // handle hot reload for CSS modules.
+              // we store the exported locals in an object and proxy to it by
+              // defining getters inside component instances' lifecycle hook.
+              styleInjectionCode +=
+                invokeStyle(`cssModules["${moduleName}"] = ${requireString}`) +
+                `Object.defineProperty(this, "${moduleName}", { get: function () { return cssModules["${moduleName}"] }})\n`
+
+              var requirePath = getRequireString('styles', style, i, style.scoped)
+              output +=
+                `module.hot && module.hot.accept([${requirePath}], function () {\n` +
+                // 1. check if style has been injected
+                `  var oldLocals = cssModules["${moduleName}"]\n` +
+                `  if (!oldLocals) return\n` +
+                // 2. re-import (side effect: updates the <style>)
+                `  var newLocals = ${requireString}\n` +
+                // 3. compare new and old locals to see if selectors changed
+                `  if (JSON.stringify(newLocals) === JSON.stringify(oldLocals)) return\n` +
+                // 4. locals changed. Update and force re-render.
+                `  cssModules["${moduleName}"] = newLocals\n` +
+                `  require("${hotReloadAPIPath}").rerender("${moduleId}")\n` +
+                `})\n`
+            }
+          }
+        } else {
+          styleInjectionCode += invokeStyle(requireString)
+        }
+      })
+      styleInjectionCode += '}\n'
+      output += styleInjectionCode
+    }
+
+    // we require the component normalizer function, and call it like so:
+    // normalizeComponent(
+    //   scriptExports,
+    //   compiledTemplate,
+    //   injectStyles,
+    //   scopeId,
+    //   moduleIdentifier (server only)
+    // )
+    output += 'var normalizeComponent = require(' +
+      loaderUtils.stringifyRequest(loaderContext, '!' + componentNormalizerPath) +
+    ')\n'
+
+    // <script>
+    output += '/* script */\n'
+    var script = parts.script
+    if (script) {
+      if (options.esModule) {
+        output += script.src
+          ? getImportForImport('script', script)
+          : getImport('script', script) + '\n'
+      } else {
+        output += 'var __vue_script__ = ' + (script.src
+          ? getRequireForImport('script', script)
+          : getRequire('script', script)) + '\n'
+      }
+      // inject loader interop
+      if (query.inject) {
+        output += '__vue_script__ = __vue_script__(injections)\n'
+      }
+    } else {
+      output += 'var __vue_script__ = null\n'
+    }
+
+    // <template>
+    output += '/* template */\n'
+    var template = parts.template
+    if (template) {
+      if (options.esModule) {
+        output += (template.src
+          ? getImportForImport('template', template)
+          : getImport('template', template)) + '\n'
+      } else {
+        output += 'var __vue_template__ = ' + (template.src
+          ? getRequireForImport('template', template)
+          : getRequire('template', template)) + '\n'
+      }
+    } else {
+      output += 'var __vue_template__ = null\n'
+    }
+
+    // style
+    output += '/* styles */\n'
+    output += 'var __vue_styles__ = ' + (parts.styles.length ? 'injectStyle' : 'null') + '\n'
+
+    // scopeId
+    output += '/* scopeId */\n'
+    output += 'var __vue_scopeId__ = ' + (hasScoped ? JSON.stringify(moduleId) : 'null') + '\n'
+
+    // moduleIdentifier (server only)
+    output += '/* moduleIdentifier (server only) */\n'
+    output += 'var __vue_module_identifier__ = ' + (isServer ? JSON.stringify(hash(this.request)) : 'null') + '\n'
+
+    // close normalizeComponent call
+    output += 'var Component = normalizeComponent(\n' +
+      '  __vue_script__,\n' +
+      '  __vue_template__,\n' +
+      '  __vue_styles__,\n' +
+      '  __vue_scopeId__,\n' +
+      '  __vue_module_identifier__\n' +
+      ')\n'
+
+    // development-only code
+    if (!isProduction) {
+      // add filename in dev
+      output += 'Component.options.__file = ' + JSON.stringify(shortFilePath) + '\n'
+      // check named exports
+      output +=
+        'if (Component.esModule && Object.keys(Component.esModule).some(function (key) {' +
+          'return key !== "default" && key.substr(0, 2) !== "__"' +
+        '})) {' +
+          'console.error("named exports are not supported in *.vue files.")' +
+        '}\n'
+      // check functional components used with templates
+      if (template) {
+        output +=
+          'if (Component.options.functional) {' +
+            'console.error("' +
+            '[vue-loader] ' + fileName + ': functional components are not ' +
+            'supported with templates, they should use render functions.' +
+          '")}\n'
+      }
+    }
+
+    // add requires for customBlocks
+    if (parts.customBlocks && parts.customBlocks.length) {
+      var addedPrefix = false
+
+      parts.customBlocks.forEach(function (customBlock, i) {
+        if (loaders[customBlock.type]) {
+          // require customBlock
+          customBlock.src = customBlock.attrs.src
+          var requireString = customBlock.src
+            ? getRequireForImport(customBlock.type, customBlock)
+            : getRequire(customBlock.type, customBlock, i)
+
+          if (!addedPrefix) {
+            output += '\n/* customBlocks */\n'
+            addedPrefix = true
+          }
+
+          output +=
+            'var customBlock = ' + requireString + '\n' +
+            'if (typeof customBlock === "function") {' +
+              'customBlock(Component)' +
+            '}\n'
+        }
+      })
+
+      output += '\n'
+    }
+
+    if (!query.inject) {
+      // hot reload
+      if (needsHotReload) {
+        output +=
+          '\n/* hot reload */\n' +
+          'if (module.hot) {(function () {\n' +
+          '  var hotAPI = require("' + hotReloadAPIPath + '")\n' +
+          '  hotAPI.install(require("vue"), false)\n' +
+          '  if (!hotAPI.compatible) return\n' +
+          '  module.hot.accept()\n' +
+          '  if (!module.hot.data) {\n' +
+          // initial insert
+          '    hotAPI.createRecord("' + moduleId + '", Component.options)\n' +
+          '  } else {\n'
+        // update
+        if (cssModules) {
+          output +=
+          '    if (module.hot.data.cssModules && Object.keys(module.hot.data.cssModules) !== Object.keys(cssModules)) {\n' +
+          '      delete Component.options._Ctor\n' +
+          '    }\n'
+        }
+        output +=
+          '    hotAPI.reload("' + moduleId + '", Component.options)\n' +
+          '  }\n'
+        // dispose
+        output +=
+          '  module.hot.dispose(function (data) {\n' +
+          (cssModules ? '    data.cssModules = cssModules\n' : '') +
+          '    disposed = true\n' +
+          '  })\n'
+        output += '})()}\n'
+      }
+      // final export
+      if (options.esModule) {
+        output += '\nexport default Component.exports\n'
+      } else {
+        output += '\nmodule.exports = Component.exports\n'
+      }
+    } else {
+      // inject-loader support
+      output =
+        '\n/* dependency injection */\n' +
+        'module.exports = function (injections) {\n' + output + '\n' +
+        '\nreturn Component.exports\n}'
+    }
+
+    // done
+    return output
+  }
 
   function getRequire (type, part, index, scoped) {
     return 'require(' +

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "consolidate": "^0.14.0",
     "hash-sum": "^1.0.2",
     "js-beautify": "^1.6.3",
+    "loader-fs-cache": "^1.0.1",
     "loader-utils": "^1.1.0",
     "lru-cache": "^4.0.1",
     "postcss": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,6 +1752,14 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
 find-cache-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
@@ -2481,6 +2489,13 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+loader-fs-cache@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz#56e0bf08bd9708b26a765b68509840c8dec9fdbc"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    mkdirp "0.5.1"
+
 loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
@@ -3017,6 +3032,12 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This is a quick and dirty POC to investigate use of cache similar to [`eslint-loader`](https://github.com/MoOx/eslint-loader#cache-default-false) and [`babel-loader`](https://github.com/babel/babel-loader#options). I have no prior experience with vue-loader and webpack loader API :bowing_man: 

Opening this PR to discuss the addition of feature. 

The `cache` is implemented similar to [`eslint-loader`](https://github.com/MoOx/eslint-loader/blob/master/index.js#L192-L212) and uses the [published version](https://github.com/viankakrisna/loader-fs-cache) of [`fs-cache`](https://github.com/babel/babel-loader/blob/master/src/fs-cache.js) used by babel.

I created a function `generateOutput` which is essentially the same code which was running inside the exported function but can be called to generate the output from content.

Although I successfully used this in a local project using `npm link`, I did not notice any reduction in build time. I confirmed that _it was_ indeed using the cache and the function `generateOutput` was not called on  subsequent builds.  

Thoughts?