### PR TITLE
[Doc EN] — Several files — Consistency changes

### DIFF
--- a/docs/en/configurations/advanced.md
+++ b/docs/en/configurations/advanced.md
@@ -10,7 +10,7 @@ Sometimes you may want to:
 
 To do that, specify the `loaders` option for `vue-loader`:
 
-> Note that `preLoaders` and `postLoaders` are only supported in >=10.3.0
+> Note that `preLoaders` and `postLoaders` are only supported in 10.3.0+
 
 ### Webpack 2.x
 

--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -64,14 +64,14 @@ module.exports = {
 ### preLoaders
 
 - type: `{ [lang: string]: string }`
-- only supported in >=10.3.0
+- only supported in 10.3.0+
 
   The config format is the same as `loaders`, but `preLoaders` are applied to corresponding language blocks before the default loaders. You can use this to pre-process language blocks - a common use case would be build-time i18n.
 
 ### postLoaders
 
 - type: `{ [lang: string]: string }`
-- only supported in >=10.3.0
+- only supported in 10.3.0+
 
   The config format is the same as `loaders`, but `postLoaders` are applied after the default loaders. You can use this to post-process language blocks. However note that this is a bit more complicated:
 
@@ -81,7 +81,7 @@ module.exports = {
 
 ### postcss
 
-> Note: in >=11.0.0 it is recommended to use a PostCSS config file instead. [The usage is the same as `postcss-loader`](https://github.com/postcss/postcss-loader#usage).
+> Note: in 11.0.0+ it is recommended to use a PostCSS config file instead. [The usage is the same as `postcss-loader`](https://github.com/postcss/postcss-loader#usage).
 
 - type: `Array` or `Function` or `Object`
 


### PR DESCRIPTION
Some changes we have made from French documentation.

- Change all `>=` to `+` for consistency accross all Vue documentation.

Feel free to not accept point that not feet your needs for English documentation.

- Vue : https://github.com/vuejs/vuejs.org/pull/1025/
- Vue Server Renderer : https://github.com/vuejs/vue-ssr-docs/pull/106/