### PR TITLE
fix(transform-require): support ~/ aliases

### DIFF
--- a/lib/template-compiler/modules/transform-require.js
+++ b/lib/template-compiler/modules/transform-require.js
@@ -40,7 +40,8 @@ function rewrite (attr, name) {
     var firstChar = value.charAt(1)
     if (firstChar === '.' || firstChar === '~') {
       if (firstChar === '~') {
-        value = '"' + value.slice(2)
+        var secondChar = value.charAt(2)
+        value = '"' + value.slice(secondChar === '/' ? 3 : 2)
       }
       attr.value = `require(${value})`
     }

--- a/test/fixtures/resolve.vue
+++ b/test/fixtures/resolve.vue
@@ -2,10 +2,12 @@
 <div>
   <img src="./logo.png">
   <img src="~fixtures/logo.png">
+  <img src="~/fixtures/logo.png">
 </div>
 </template>
 
 <style>
 html { background-image: url(./logo.png); }
 body { background-image: url(~fixtures/logo.png); }
+body { background-image: url(~/fixtures/logo.png); }
 </style>


### PR DESCRIPTION
Hi. Recently we encounter a problem with Nuxt usage of aliases inside `.vue` files. The problem is that if aliases begin with `~/assets/logo.png` they will work with normal webpack requires but `vue-loader` tries to convert them to something like `/assets/logo.png` which is not a valid path. This PR fixes this condition and also adds appreciate tests.

Related issues:
- nuxt/nuxt.js#1241
- nuxt/nuxt.js#1257
- [this](https://github.com/nuxt/nuxt.js/commit/1f85b2dd13622575dbf0d2569d7486152d261d13) discussion