### PR TITLE
Dont add postcss loader gratuitously

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -547,7 +547,11 @@ module.exports = function (content) {
           return defaultLoaders.html + '!' + templatePreprocessorPath + '?engine=' + lang + '!'
         case 'styles':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
-          return loader + '!' + styleCompiler + ensureBang(ensureLoader(lang))
+          loader = loader + '!' + styleCompiler
+          if(lang === 'postcss') {
+            return loader
+          }
+          return ensureBang(ensureLoader(lang))
         case 'script':
           return injectString + ensureBang(ensureLoader(lang))
         default:

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -548,7 +548,7 @@ module.exports = function (content) {
         case 'styles':
           loader = addCssModulesToLoader(defaultLoaders.css, part, index)
           loader = loader + '!' + styleCompiler
-          if(lang === 'postcss') {
+          if (lang === 'postcss') {
             return loader
           }
           return ensureBang(ensureLoader(lang))


### PR DESCRIPTION
If the user has not configured any special options for postcss within vue loader and has not added any special query params within the lang attribute (i.e. they just declared <style lang="postcss">) then they probably just wanted syntax highlighting, because postcss is already being run on theystyles. 

In PostCSS 6 and the latest postcss-loader you get a warning message for not having sourceMaps options for postcss.  If you simply enable sourceMaps within your postcss.config.js and don't add lang="postcss" to your style tag, the warning goes away and sourceMaps works.  However, doing this results in losing syntax highlighting for your postcss specific syntax.  I looked into vue loader and it looks like if all you want is syntax highlighting and postcss is already being run on the styles anyways, then by not adding postcss loader to the raw loader string you can avoid sourceMaps warnings. 

This could also be a change for vue syntax highlighting projects.  Perhaps as a community syntax highlighters should offfer another attribute that can be used to declare what syntax highlighting to show that isnt directly tied to what webpack loader should get run