### PR TITLE
docs(EN,JA,RU): fix webpack template utils filename

### DIFF
--- a/docs/en/configurations/pre-processors.md
+++ b/docs/en/configurations/pre-processors.md
@@ -56,7 +56,7 @@ Then add the following webpack rule:
 }
 ```
 
-As an example, if you are using [vuejs-templates/webpack](https://github.com/vuejs-templates/webpack), modify `build/util.js` like so:
+As an example, if you are using [vuejs-templates/webpack](https://github.com/vuejs-templates/webpack), modify `build/utils.js` like so:
 
 ``` js
 scss: generateLoaders('sass').concat(

--- a/docs/ja/configurations/pre-processors.md
+++ b/docs/ja/configurations/pre-processors.md
@@ -56,7 +56,7 @@ npm install sass-resources-loader --save-dev
 }
 ```
 
-例として、[vuejs-templates/webpack](https://github.com/vuejs-templates/webpack) を使用している場合、 `build/util.js` を以下のように変更してください:
+例として、[vuejs-templates/webpack](https://github.com/vuejs-templates/webpack) を使用している場合、 `build/utils.js` を以下のように変更してください:
 
 ``` js
 scss: generateLoaders('sass').concat(

--- a/docs/ru/configurations/pre-processors.md
+++ b/docs/ru/configurations/pre-processors.md
@@ -56,7 +56,7 @@ npm install sass-resources-loader --save-dev
 }
 ```
 
-Например, если вы используете [vuejs-templates/webpack](https://github.com/vuejs-templates/webpack), измените файл `build/util.js` таким образом:
+Например, если вы используете [vuejs-templates/webpack](https://github.com/vuejs-templates/webpack), измените файл `build/utils.js` таким образом:
 
 ``` js
 scss: generateLoaders('sass').concat(


### PR DESCRIPTION
Replace the file path `build/util.js` by the correct `build/utils.js` of the [webpack template](https://github.com/vuejs-templates/webpack/blob/master/template/build/utils.js)