### PR TITLE
fix js-beautify version to 1.6.14, since js-beautify@1.7.0 is fucked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ test/output
 docs/_book
 .DS_Store
 .idea
+.history
 *.iml

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "consolidate": "^0.14.0",
     "hash-sum": "^1.0.2",
-    "js-beautify": "^1.6.14",
+    "js-beautify": "1.6.14",
     "loader-utils": "^1.1.0",
     "lru-cache": "^4.1.1",
     "postcss": "^6.0.6",


### PR DESCRIPTION
vue-loader specify the version of js-beautify as ^1.6.14, which will allow the installation of js-beautify@1.7.0.

But package js-beautify@1.7.0 is not published correctly: https://github.com/beautify-web/js-beautify/issues/1247.

Temporarily fix its version to 1.6.14 can solve this problem.