### PR TITLE
[zh-cn] synced from #eb748f2 to #5e549cb

### DIFF
--- a/docs/zh-cn/SUMMARY.md
+++ b/docs/zh-cn/SUMMARY.md
@@ -7,6 +7,7 @@
   - [CSS Modules](features/css-modules.md)
   - [PostCSS](features/postcss.md)
   - [热重载](features/hot-reload.md)
+  - [函数式组件](features/functional.md)
 - 配置
   - [预处理器](configurations/pre-processors.md)
   - [资源路径处理](configurations/asset-url.md)
@@ -23,6 +24,7 @@
   - [preLoaders](options.md#preloaders)
   - [postLoaders](options.md#postloaders)
   - [postcss](options.md#postcss)
+  - [postcss.config](options.md#postcssconfig)
   - [cssSourceMap](options.md#csssourcemap)
   - [esModule](options.md#esmodule)
   - [preserveWhitespace](options.md#preservewhitespace)
@@ -32,3 +34,4 @@
   - [buble](options.md#buble)
   - [extractCSS](options.md#extractcss)
   - [optimizeSSR](options.md#optimizessr)
+  - [cacheBusting](options.md#cachebusting)

--- a/docs/zh-cn/options.md
+++ b/docs/zh-cn/options.md
@@ -114,17 +114,17 @@ module.exports = {
   ```
 
 ### postcss.config
-<!-- @todo translation -->
-> New in 13.2.1
 
-- type: `Object`
-- default: `undefined`
+> 13.2.1 新增
 
-  This field allows customizing PostCSS config in the same way as [postcss-loader](https://github.com/postcss/postcss-loader#config-1).
+- 类型：`Object`
+- 默认值：`undefined`
+
+  这个字段允许用 [postcss-loader](https://github.com/postcss/postcss-loader#config-1) 同样的方式自定义 PostCSS 插件。
 
   - **postcss.config.path**
 
-    Specify a path (file or directory) to load the PostCSS config file from.
+    指定一个加载 PostCSS 配置文件的路径 (文件或目录)。
 
     ``` js
     postcss: {
@@ -136,7 +136,7 @@ module.exports = {
 
   - **postcss.config.ctx**
 
-    Provide context to PostCSS plugins. See [postcss-loader docs](https://github.com/postcss/postcss-loader#context-ctx) for more details.
+    向 PostCSS 插件提供上下文。详见 [postcss-loader 文档](https://github.com/postcss/postcss-loader#context-ctx)。
 
 ### cssSourceMap
 
@@ -299,10 +299,10 @@ module.exports = {
 开启 Vue 2.4 服务端渲染的编译优化之后，渲染函数将会把返回的 vdom 树的一部分编译为字符串，以提升服务端渲染的性能。在一些情况下，你可能想要明确的将其关掉，因为该渲染函数只能用于服务端渲染，而不能用于客户端渲染或测试环境。
 
 ### cacheBusting
-<!-- @todo translation -->
-> New in 13.2.0
 
-- type: `boolean`
-- default: `true` in development mode, `false` in production mode.
+> 13.2.0 新增
 
-Whether generate source maps with cache busting by appending a hash query to the file name. Turning this off can help with source map debugging.
+- 类型：`boolean`
+- 默认值：在开发环境下是 `true`，在生产环境下是 `false`。
+
+是否通过给文件名后加哈希查询值来避免生成的 source map 被缓存。关掉这一选项有益于 source map 调试。

--- a/docs/zh-cn/options.md
+++ b/docs/zh-cn/options.md
@@ -113,6 +113,31 @@ module.exports = {
   }
   ```
 
+### postcss.config
+<!-- @todo translation -->
+> New in 13.2.1
+
+- type: `Object`
+- default: `undefined`
+
+  This field allows customizing PostCSS config in the same way as [postcss-loader](https://github.com/postcss/postcss-loader#config-1).
+
+  - **postcss.config.path**
+
+    Specify a path (file or directory) to load the PostCSS config file from.
+
+    ``` js
+    postcss: {
+      config: {
+        path: path.resolve('./src')
+      }
+    }
+    ```
+
+  - **postcss.config.ctx**
+
+    Provide context to PostCSS plugins. See [postcss-loader docs](https://github.com/postcss/postcss-loader#context-ctx) for more details.
+
 ### cssSourceMap
 
 - 类型: `Boolean`
@@ -272,3 +297,12 @@ module.exports = {
 - 默认值: 当 webpack 配置中包含 `target: 'node'` 且 `vue-template-compiler` 版本号大于等于 2.4.0 时为 `true`。
 
 开启 Vue 2.4 服务端渲染的编译优化之后，渲染函数将会把返回的 vdom 树的一部分编译为字符串，以提升服务端渲染的性能。在一些情况下，你可能想要明确的将其关掉，因为该渲染函数只能用于服务端渲染，而不能用于客户端渲染或测试环境。
+
+### cacheBusting
+<!-- @todo translation -->
+> New in 13.2.0
+
+- type: `boolean`
+- default: `true` in development mode, `false` in production mode.
+
+Whether generate source maps with cache busting by appending a hash query to the file name. Turning this off can help with source map debugging.

--- a/docs/zh-cn/workflow/testing-with-mocks.md
+++ b/docs/zh-cn/workflow/testing-with-mocks.md
@@ -65,6 +65,6 @@ it('should render', () => {
       'test': ExampleWithMocks
     }
   }).$mount()
-  expect(vm.$el.querySelector('.msg').textContent).toBe('Hello from a mocked service!')
+  expect(vm.$el.querySelector('.msg').textContent).to.equal('Hello from a mocked service!')
 })
 ```


### PR DESCRIPTION
ref: `/docs/en/*` parts of https://github.com/vuejs/vue-loader/compare/eb748f2...5e549cb

/ping @Justineo 