### PR TITLE
fix srcset transform module not resovling alias path

### DIFF
--- a/lib/template-compiler/modules/transform-srcset.js
+++ b/lib/template-compiler/modules/transform-srcset.js
@@ -47,7 +47,7 @@ function urlToRequire (url) {
   if (firstChar === '.' || firstChar === '~') {
     if (firstChar === '~') {
       var secondChar = url.charAt(1)
-      url = '"' + url.slice(secondChar === '/' ? 2 : 1)
+      url = url.slice(secondChar === '/' ? 2 : 1)
     }
     return `require("${url}")`
   }

--- a/test/fixtures/transform.vue
+++ b/test/fixtures/transform.vue
@@ -5,12 +5,20 @@
     <image xlink:href="./logo.png" />
   </svg>
   <img src="./logo.png" srcset="./logo.png 2x">
+  <img src="./logo.png" srcset="~fixures/logo.png 2x">
   <img src="./logo.png" srcset="./logo.png 2x, ./logo.png 3x">
+  <img src="./logo.png" srcset="~fixures/logo.png 2x, ~fixures/logo.png 3x">
   <img
     src="./logo.png"
     srcset="
       ./logo.png 2x,
       ./logo.png 3x
+  ">
+  <img 
+    src="./logo.png" 
+    srcset="
+      ~fixures/logo.png 2x,
+      ~fixures/logo.png 3x
   ">
 </div>
 </template>

--- a/test/test.js
+++ b/test/test.js
@@ -415,6 +415,11 @@ describe('vue-loader', () => {
 
   it('transformToRequire option', done => {
     test({
+      resolve: {
+        alias: {
+          fixures: path.resolve(__dirname, 'fixtures')
+        }
+      },
       entry: './test/fixtures/transform.vue',
       module: {
         rules: [
@@ -440,10 +445,16 @@ describe('vue-loader', () => {
 
       // image tag with srcset
       expect(vnode.children[4].data.attrs.srcset).to.equal(dataURL + ' 2x')
+      // image tag with alias srcset
+      expect(vnode.children[6].data.attrs.srcset).to.equal(dataURL + ' 2x')
       // image tag with srcset with two candidates
-      expect(vnode.children[6].data.attrs.srcset).to.equal(dataURL + ' 2x, ' + dataURL + ' 3x')
-      // image tag with multiline srcset
       expect(vnode.children[8].data.attrs.srcset).to.equal(dataURL + ' 2x, ' + dataURL + ' 3x')
+      // image tag with alias srcset with two candidates
+      expect(vnode.children[10].data.attrs.srcset).to.equal(dataURL + ' 2x, ' + dataURL + ' 3x')
+      // image tag with multiline srcset
+      expect(vnode.children[12].data.attrs.srcset).to.equal(dataURL + ' 2x, ' + dataURL + ' 3x')
+      // image tag with alias multiline srcset
+      expect(vnode.children[14].data.attrs.srcset).to.equal(dataURL + ' 2x, ' + dataURL + ' 3x')
 
       // style
       expect(includeDataURL(style)).to.equal(true)


### PR DESCRIPTION
srcset transform module cannot handle alias path correctly.
e.g.
```javascript
<img srcset="~assets/logo@2x.png 2x" />
```
It is caused by parsing url started with ```~``` in ```/lib/template-compiler/modules/transform-srcset.js```, line 50.
Fixed with more test unit is added in ```test.js```
After all, many thanks to @AndreKR 's adding support for ```srcset```