### PR TITLE
only generate css source map when cssSourceMap is enabled

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -97,7 +97,7 @@ module.exports = function (content) {
 
   let output = ''
   const bustCache = !isProduction && options.cacheBusting !== false
-  const parts = parse(content, fileName, this.sourceMap, sourceRoot, bustCache)
+  const parts = parse(content, fileName, this.sourceMap, sourceRoot, bustCache, options)
   const hasScoped = parts.styles.some(({ scoped }) => scoped)
   const templateAttrs =
     parts.template && parts.template.attrs && parts.template.attrs

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,7 +6,7 @@ const SourceMapGenerator = require('source-map').SourceMapGenerator
 const splitRE = /\r?\n/g
 const emptyRE = /^(?:\/\/)?\s*$/
 
-module.exports = (content, filename, needMap, sourceRoot, bustCache) => {
+module.exports = (content, filename, needMap, sourceRoot, bustCache, options) => {
   const cacheKey = hash(filename + content)
   // source-map cache busting for hot-reloadded modules
   const filenameWithHash = bustCache
@@ -24,7 +24,7 @@ module.exports = (content, filename, needMap, sourceRoot, bustCache) => {
         sourceRoot
       )
     }
-    if (output.styles) {
+    if (output.styles && options.cssSourceMap) {
       output.styles.forEach(style => {
         if (!style.src) {
           style.map = generateSourceMap(


### PR DESCRIPTION
Please only generate css source map when cssSourceMap is enabled. 

Or it will cause the postcss-loader to throw a warning: `Previous source map found, but options.sourceMap isn't set`

The warning is triggered under this condition
```
if (sourceMap == undefined && map) {
      this.emitWarning(`\n\n ⚠️  PostCSS Loader\n\nPrevious source map found, but options.sourceMap isn't set.\nIn this case the loader will discard the source map entirely for performance reasons.\nSee https://github.com/postcss/postcss-loader#sourcemap for more information.\n\n`)
}
```