### PR TITLE
Small code fix for hot-reload

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -400,7 +400,7 @@ module.exports = function (content) {
       output +=
         `    hotAPI.${
           functionalTemplate ? 'rerender' : 'reload'
-        }("${moduleId}", Component.options)\n' + '  }\n`
+        }("${moduleId}", Component.options)\n  }\n`
       // dispose
       output +=
         '  module.hot.dispose(function (data) {\n' +


### PR DESCRIPTION
Removed the unnecessary string concatenation, though it's no error caused.

Generated code before this fix:

```js
/* hot reload */
if (module.hot) {(function () {
  var hotAPI = require("vue-loader/node_modules/vue-hot-reload-api")
  hotAPI.install(require("vue"), false)
  if (!hotAPI.compatible) return
  module.hot.accept()
  if (!module.hot.data) {
    hotAPI.createRecord("data-v-7ba5bd90", Component.options)
  } else {
    hotAPI.reload("data-v-7ba5bd90", Component.options)
' + '  }
  module.hot.dispose(function (data) {
    disposed = true
  })
})()}
```

Thanks.