### PR TITLE
hash all filepath and content in production to fix #1084

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -82,7 +82,7 @@ module.exports = function (content) {
     process.cwd()
   const sourceRoot = path.dirname(path.relative(context, filePath))
   const shortFilePath = path.relative(context, filePath).replace(/^(\.\.[\\\/])+/, '')
-  const moduleId = 'data-v-' + hash(isProduction ? content : shortFilePath)
+  const moduleId = 'data-v-' + hash(isProduction ? (shortFilePath + '\n' + content) : shortFilePath)
 
   let cssLoaderOptions = ''
   if (!isProduction && this.sourceMap && options.cssSourceMap !== false) {


### PR DESCRIPTION
Ref: #1084 

Seems hashing the `shortFilePath` only is enough. But I am not sure whether the `content` is need to be hashed in production. So finally just concat them together and hash it all.

Thanks.