### PR TITLE
add babel configure options

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -106,8 +106,7 @@ module.exports = function (content) {
   const babelOptions =
     hasBabel && options.bable ? '?' + JSON.stringify(options.bable) : ''
 
-
-    let output = ''
+  let output = ''
 
   const parts = parse(
     content,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -103,7 +103,11 @@ module.exports = function (content) {
   const bubleOptions =
     hasBuble && options.buble ? '?' + JSON.stringify(options.buble) : ''
 
-  let output = ''
+  const babelOptions =
+    hasBabel && options.bable ? '?' + JSON.stringify(options.bable) : ''
+
+
+    let output = ''
 
   const parts = parse(
     content,
@@ -148,7 +152,7 @@ module.exports = function (content) {
       : styleLoaderPath + '!' + 'css-loader' + cssLoaderOptions,
     js: hasBuble
       ? 'buble-loader' + bubleOptions
-      : hasBabel ? 'babel-loader' : ''
+      : hasBabel ? 'babel-loader' + babelOptions : ''
   }
 
   // check if there are custom loaders specified via


### PR DESCRIPTION
```
<template>
    <div>
        <test1 />
        <test2 />
    </div>
</template>
<script>
    const test1 = ()=>import('./component/a.vue');
    const test2 = ()=>import('./component/b.vue');
    export default {
        components:{
            test1,test2
        }
    }
</script>
```
fix some case if user need configure  bable option,like upper code sentence,i need configure  `syntax-dynamic-import` to reslove dynamic import or other problem.

code refferred from loader.js bubleOptions.

and then config like this:
```
{
                test: /\.vue$/,
                exclude: /(node_modules|bower_components)/,
                use: {
                    loader: 'vue-loader',
                    options:{
                        bable:{
                            presets: ['babel-preset-env'],
                            plugins:[
                                'syntax-dynamic-import'
                            ]
                        }
                    }
                }
            }
```
  