### PR TITLE
前 => 间

### DIFF
--- a/docs/zh-cn/options.md
+++ b/docs/zh-cn/options.md
@@ -168,7 +168,7 @@ module.exports = {
 - 类型: `Boolean`
 - 默认值: `true`
 
-  如果设置为 `false`，模版中 HTML 标签之前的空格将会被忽略。
+  如果设置为 `false`，模版中 HTML 标签之间的空格将会被忽略。
 
 ### compilerModules
 


### PR DESCRIPTION
the whitespaces between HTML tags in templates will be ignored.

模版中 HTML 标签之前的空格将会被忽略。 => 模版中 HTML 标签之间的空格将会被忽略。