### PR TITLE
Support multiple rule definitions

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -69,16 +69,21 @@ module.exports = function (content) {
     options.esModule = false
   }
 
-  let vueOptionId = 0
-  if (this.options.__vueOptions__ && this.options.__vueOptions__ !== options) {
-    if (!this.options.__vueOptionsList__) {
-      Object.defineProperty(this.options, '__vueOptionsList__', {
-        value: [this.options.__vueOptions__],
-        enumerable: false,
-        configurable: true
-      })
-    }
-    vueOptionId = this.options.__vueOptionsList__.push(options) - 1
+  if (!this.options.__vueOptionsList__) {
+    const list = []
+    list.queryList = []
+    Object.defineProperty(this.options, '__vueOptionsList__', {
+      value: list,
+      enumerable: false,
+      configurable: true
+    })
+  }
+  const vueOptionList = this.options.__vueOptionsList__
+  const vueQueryList = vueOptionList.queryList
+  let vueOptionId = vueQueryList.indexOf(query)
+  if (vueOptionId < 0) {
+    vueQueryList.push(query)
+    vueOptionId = vueOptionList.push(options) - 1
   }
 
   // #824 avoid multiple webpack runs complaining about unknown option

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -69,6 +69,18 @@ module.exports = function (content) {
     options.esModule = false
   }
 
+  let vueOptionId = 0
+  if (this.options.__vueOptions__ && this.options.__vueOptions__ !== options) {
+    if (!this.options.__vueOptionsList__) {
+      Object.defineProperty(this.options, '__vueOptionsList__', {
+        value: [this.options.__vueOptions__],
+        enumerable: false,
+        configurable: true
+      })
+    }
+    vueOptionId = this.options.__vueOptionsList__.push(options) - 1
+  }
+
   // #824 avoid multiple webpack runs complaining about unknown option
   Object.defineProperty(this.options, '__vueOptions__', {
     value: options,
@@ -134,6 +146,7 @@ module.exports = function (content) {
       transformToRequire: options.transformToRequire,
       preserveWhitespace: options.preserveWhitespace,
       buble: bubleTemplateOptions,
+      optionId: vueOptionId,
       // only pass compilerModules if it's a path string
       compilerModules:
         typeof options.compilerModules === 'string'
@@ -585,7 +598,8 @@ module.exports = function (content) {
           vue: true,
           id: moduleId,
           scoped: !!scoped,
-          hasInlineConfig: !!query.postcss
+          hasInlineConfig: !!query.postcss,
+          optionId: vueOptionId
         }) +
         '!'
       // normalize scss/sass/postcss if no specific loaders have been provided
@@ -642,6 +656,8 @@ module.exports = function (content) {
             templatePreprocessorPath +
             '?engine=' +
             lang +
+            '&optionId=' +
+            vueOptionId +
             '!'
           )
         case 'styles':

--- a/lib/style-compiler/index.js
+++ b/lib/style-compiler/index.js
@@ -10,7 +10,9 @@ module.exports = function (css, map) {
   const cb = this.async()
 
   const query = loaderUtils.getOptions(this) || {}
-  let vueOptions = this.options.__vueOptions__
+  let vueOptions = this.options.__vueOptionsList__ && this.options.__vueOptionsList__[query.optionId]
+    ? this.options.__vueOptionsList__[query.optionId]
+    : this.options.__vueOptions__
 
   if (!vueOptions) {
     if (query.hasInlineConfig) {

--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -11,8 +11,10 @@ module.exports = function (html) {
   this.cacheable()
   const isServer = this.target === 'node'
   const isProduction = this.minimize || process.env.NODE_ENV === 'production'
-  const vueOptions = this.options.__vueOptions__ || {}
   const options = loaderUtils.getOptions(this) || {}
+  const vueOptions = this.options.__vueOptionsList__ && this.options.__vueOptionsList__[options.optionId]
+    ? this.options.__vueOptionsList__[options.optionId]
+    : (this.options.__vueOptions__ || {})
   const needsHotReload = !isServer && !isProduction && vueOptions.hotReload !== false
   const defaultModules = [transformRequire(options.transformToRequire), transformSrcset()]
   let userModules = vueOptions.compilerModules || options.compilerModules

--- a/lib/template-compiler/preprocessor.js
+++ b/lib/template-compiler/preprocessor.js
@@ -19,9 +19,12 @@ module.exports = function (content) {
     )
   }
 
+  const vueOptions = this.options.__vueOptionsList__ && this.options.__vueOptionsList__[opt.optionId]
+    ? this.options.__vueOptionsList__[opt.optionId]
+    : this.options.__vueOptions__
   // allow passing options to the template preprocessor via `template` option
-  if (this.options.__vueOptions__) {
-    Object.assign(opt, this.options.__vueOptions__.template)
+  if (vueOptions) {
+    Object.assign(opt, vueOptions.template)
   }
 
   // for relative includes

--- a/test/fixtures/multiple-rules-1.vue
+++ b/test/fixtures/multiple-rules-1.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="multiple-rule">Hello World</div>
+</template>
+
+<style>
+.multiple-rule-1 {
+  font-size: 7px;
+}
+</style>

--- a/test/fixtures/multiple-rules-2.vue
+++ b/test/fixtures/multiple-rules-2.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="multiple-rule">Hello World</div>
+</template>
+
+<style>
+.multiple-rule-2 {
+  font-size: 28px;
+}
+</style>

--- a/test/fixtures/multiple-rules.js
+++ b/test/fixtures/multiple-rules.js
@@ -1,0 +1,4 @@
+import Rule1 from './multiple-rules-1.vue'
+import Rule2 from './multiple-rules-2.vue'
+
+window.rules = [Rule1, Rule2]


### PR DESCRIPTION
In my case I need to define different loader options, one for my own codes, and the other one for some third-party codes. Howerver, vue-loader repeatedly mounts `__vueOptions__` to `this.options` and finally options get overridden. Now I pass an  `optionId` to internal compilers to resolve the correct one.

An example is given in the test.