### PR TITLE
Fix for 'loader.charAt is not a function' in v8

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -171,6 +171,11 @@ module.exports = function (content) {
   }
 
   function ensureBang (loader) {
+    if (Array.isArray(loader)) {
+      loader = stringifyLoaders(loader)
+    } else if (typeof loader === 'object') {
+      loader = stringifyLoaders([loader])
+    }
     if (loader.charAt(loader.length - 1) !== '!') {
       return loader + '!'
     }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -123,6 +123,8 @@ module.exports = function (content) {
     if (loader !== undefined) {
       if (Array.isArray(loader)) {
         loader = stringifyLoaders(loader)
+      } else if (typeof loader === 'object') {
+        loader = stringifyLoaders([loader])
       }
 
       if (type === 'style') {
@@ -171,11 +173,6 @@ module.exports = function (content) {
   }
 
   function ensureBang (loader) {
-    if (Array.isArray(loader)) {
-      loader = stringifyLoaders(loader)
-    } else if (typeof loader === 'object') {
-      loader = stringifyLoaders([loader])
-    }
     if (loader.charAt(loader.length - 1) !== '!') {
       return loader + '!'
     }


### PR DESCRIPTION
I have some older project still runnig on Vue 1 and crash on 'loader.charAt is not a function' error like in the #624 issue.
I am not javascript expert, but this edit solve my issue and maybe can solve also for other.