### PR TITLE
fix: get transformToRequire from vueOptions instead of options for template-compiler (#1171)

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -14,7 +14,7 @@ module.exports = function (html) {
   const vueOptions = this._compilation.__vueOptions__ || {}
   const options = loaderUtils.getOptions(this) || {}
   const needsHotReload = !isServer && !isProduction && vueOptions.hotReload !== false
-  const defaultModules = [transformRequire(options.transformToRequire), transformSrcset()]
+  const defaultModules = [transformRequire(vueOptions.transformToRequire), transformSrcset()]
 
   const compilerOptions = {
     preserveWhitespace: vueOptions.preserveWhitespace,


### PR DESCRIPTION
`transformToRequire` is actually broken since v14 because compiler options is passed by `this._compilation.__vueOptions__`, instead of webpack loader option, so it should be `vueOptions.transformToRequire` here. 
Not sure why tests didn't fail for `options.transformToRequire` :/