### PR TITLE
Remove `include` before normalizing loaders, fixes #1201

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -6,8 +6,18 @@ module.exports = class VueLoaderPlugin {
   apply (compiler) {
     // get a hold of the raw rules
     const rawRules = compiler.options.module.rules
+    // remove `include` property, see #1201
+    const rawRulesWithoutInclude = rawRules.map(rule => {
+      if ('include' in rule) {
+        const copy = Object.assign({}, rule)
+        delete copy.include
+        return copy
+      } else {
+        return rule
+      }
+    })
     // use webpack's RuleSet utility to normalize user rules
-    const rawNormalizedRules = new RuleSet(rawRules).rules
+    const rawNormalizedRules = new RuleSet(rawRulesWithoutInclude).rules
 
     // find the rule that applies to vue files
     const vueRuleIndex = rawRules.findIndex((rule, i) => {


### PR DESCRIPTION
This fixes #1201 by creating a local copy of rules which use the `include` option and then removes it property from that copy.

Rules without the `include` option are not copied to spare needless operations.

**EDIT:** Also fixes #1202 (which is a duplicate of #1201).