### PR TITLE
Remove rule.loaders from normalized rules

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -135,6 +135,7 @@ function cloneRule (rule, normalizedRule, vueUse) {
 
   // delete shorthand since we have normalized use
   delete res.loader
+  delete res.loaders
   delete res.options
 
   if (rule.oneOf) {


### PR DESCRIPTION
In addition to removing the `loader` and `options` property from normalized loaders, also remove the `loaders` property. Fixes #1206.