### PR TITLE
feat(loader): support options.productionMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,4 @@ The following option has been changed to resourceQuery:
 - `transformAssetUrls`
 - `optimizeSSR`
 - `hotReload`
+- `productionMode`

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ module.exports = function (source) {
 
   const isServer = target === 'node'
   const isShadow = incomingQuery.shadow != null
-  const isProduction = minimize || process.env.NODE_ENV === 'production'
+  const isProduction = options.minimize || minimize || process.env.NODE_ENV === 'production'
   const filename = path.basename(resourcePath)
   const context = rootContext || process.cwd()
   const sourceRoot = path.dirname(path.relative(context, resourcePath))

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ module.exports = function (source) {
 
   const isServer = target === 'node'
   const isShadow = incomingQuery.shadow != null
-  const isProduction = options.minimize || minimize || process.env.NODE_ENV === 'production'
+  const isProduction = options.productionMode || minimize || process.env.NODE_ENV === 'production'
   const filename = path.basename(resourcePath)
   const context = rootContext || process.cwd()
   const sourceRoot = path.dirname(path.relative(context, resourcePath))


### PR DESCRIPTION
With webpack 4, `this.minimize` value is `undefined`. This PR allows enabling `minimize` with loader options.

----

A side note from [here](https://medium.com/webpack/webpack-4-migration-guide-for-plugins-loaders-20a79b927202):
> Guideline: Loaders should receive all options via this.query. They should not use other ways to receive options, i. e. no property in webpack options, no environment variable.