### PR TITLE
Fix webpack module concatenation support for v15

### DIFF
--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -66,5 +66,5 @@ module.exports.pitch = function (remainingRequest) {
   // both that rule and the cloned rule will match, resulting in duplicated
   // loaders. Therefore it is necessary to perform a dedupe here.
   const request = genRequest(loaders.map(toLoaderString))
-  return `module.exports = require(${request})`
+  return `import mod from ${request}; export default mod`
 }

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -37,8 +37,7 @@ module.exports.pitch = function (remainingRequest) {
         ...beforeLoaders
       ])
       // console.log(request)
-      // use cjs to ensure exports from (vue-)style-loader/css-loader are intact
-      return `module.exports = require(${request})`
+      return `import mod from ${request}; export default mod; export * from ${request}`
     }
   }
 

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -66,5 +66,5 @@ module.exports.pitch = function (remainingRequest) {
   // both that rule and the cloned rule will match, resulting in duplicated
   // loaders. Therefore it is necessary to perform a dedupe here.
   const request = genRequest(loaders.map(toLoaderString))
-  return `import mod from ${request}; export default mod`
+  return `import mod from ${request}; export default mod; export * from ${request}`
 }


### PR DESCRIPTION
Webpack's module concatenation support was broken by v15 due to this `module.exports` line. Changing to ESM export fixes this issue.