### PR TITLE
fix: ignore VueLoaderPlugin check when using thread-loader for now

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const { NS } = require('./plugin')
 module.exports = function (source) {
   const loaderContext = this
 
-  if (!loaderContext[NS]) {
+  if (!loaderContext['thread-loader'] && !loaderContext[NS]) {
     loaderContext.emitError(new Error(
       `vue-loader was used without the corresponding plugin. ` +
       `Make sure to include VueLoaderPlugin in your webpack config.`


### PR DESCRIPTION
A temporary fix for #1267 