### PR TITLE
Inject issuerPath to resourceQuery for custom blocks

### DIFF
--- a/lib/codegen/customBlocks.js
+++ b/lib/codegen/customBlocks.js
@@ -9,7 +9,7 @@ module.exports = function genCustomBlocksCode (
   return `\n/* custom blocks */\n` + blocks.map((block, i) => {
     const src = block.attrs.src || resourcePath
     const attrsQuery = attrsToQuery(block.attrs)
-    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${attrsQuery}`
+    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}&issuerPath=${qs.escape(resourcePath)}${attrsQuery}`
     return (
       `import block${i} from ${stringifyRequest(src + query)}\n` +
       `if (typeof block${i} === 'function') block${i}(component)`

--- a/lib/codegen/customBlocks.js
+++ b/lib/codegen/customBlocks.js
@@ -9,7 +9,8 @@ module.exports = function genCustomBlocksCode (
   return `\n/* custom blocks */\n` + blocks.map((block, i) => {
     const src = block.attrs.src || resourcePath
     const attrsQuery = attrsToQuery(block.attrs)
-    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}&issuerPath=${qs.escape(resourcePath)}${attrsQuery}`
+    const issuerQuery = block.attrs.src ? `&issuerPath=${qs.escape(resourcePath)}` : ''
+    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${issuerQuery}${attrsQuery}`
     return (
       `import block${i} from ${stringifyRequest(src + query)}\n` +
       `if (typeof block${i} === 'function') block${i}(component)`


### PR DESCRIPTION
When using `src` attribute on custom blocks, the requested file won't be able to know which file is actually requesting it, maybe we can directly inject `resourcePath` to the query as a workaround.