### PR TITLE
Allow use of ':name' attribute.

### DIFF
--- a/lib/codegen/utils.js
+++ b/lib/codegen/utils.js
@@ -12,13 +12,17 @@ const ignoreList = [
 // transform the attrs on a SFC block descriptor into a resourceQuery string
 exports.attrsToQuery = (attrs, langFallback) => {
   let query = ``
+  const keys = []
+
   for (const name in attrs) {
+    const key = name.replace(/^:/, '')
     const value = attrs[name]
-    if (!ignoreList.includes(name)) {
-      query += `&${qs.escape(name)}=${value ? qs.escape(value) : ``}`
+    if (!ignoreList.includes(key)) {
+      keys.push(key)
+      query += `&${qs.escape(key)}=${value ? qs.escape(value) : ``}`
     }
   }
-  if (langFallback && !(`lang` in attrs)) {
+  if (langFallback && keys.indexOf('lang') === -1) {
     query += `&lang=${langFallback}`
   }
   return query


### PR DESCRIPTION
Avoids forcing Javascript language when using lang="ts" in Jetbrains products.