### PR TITLE
fix: default parser was removed from prettier

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -77,7 +77,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)


### PR DESCRIPTION
same as [fix: default parser was removed from prettier](https://github.com/vuejs/component-compiler-utils/pull/15)