### PR TITLE
fix: check loader for cnpm(npminstall)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -53,7 +53,7 @@ class VueLoaderPlugin {
     const vueUse = vueRule.use
     // get vue-loader options
     const vueLoaderUseIndex = vueUse.findIndex(u => {
-      return /^vue-loader|(\/|\\)vue-loader/.test(u.loader)
+      return /^vue-loader|(\/|\\|@)vue-loader/.test(u.loader)
     })
 
     if (vueLoaderUseIndex < 0) {


### PR DESCRIPTION
`cnpm` (which using npminstall) install the package to the directory like:

```
~project/node_modules/_vue-loader@15.2.1@vue-loader
```

it test false using `/^vue-loader|(\/|\\)vue-loader`
