### PR TITLE
[v13] fix: Explicitly set the prettier parser to 'babylon'

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -77,7 +77,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)


### PR DESCRIPTION
Since as of Prettier 1.13.0 there is no longer a default:
prettier/prettier#4528

The `parser` option has been supported since prettier v0.0.10, so this won't break users whose lockfile still references a pre-1.13.0 release of prettier:
https://github.com/prettier/prettier/blob/1.13.0/src/main/core-options.js#L89

This is the `13.x` branch backport of:
vuejs/component-compiler-utils#15

...which will help resolve the failures we're seeing (mozilla-neutrino/neutrino-dev#913) in the latest stable release of [@neutrinojs/vue](https://www.npmjs.com/package/@neutrinojs/vue) which is still using vue-loader v13 (upgrading the v8 branch to vue-loader 15 would be a breaking change for our users).