### PR TITLE
[v14] fix: Explicitly set the prettier parser to 'babylon'

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -70,7 +70,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)


### PR DESCRIPTION
Since as of Prettier 1.13.0 there is no longer a default:
prettier/prettier#4528

The `parser` option has been supported since prettier v0.0.10, so this won't break users whose lockfile still references a pre-1.13.0 release of prettier:
https://github.com/prettier/prettier/blob/1.13.0/src/main/core-options.js#L89

This is the `v14` branch backport of:
vuejs/component-compiler-utils#15

Whilst #1322 is the more important PR for us, since it will help fix the Neutrino 8 (stable) branch, this PR:
* fixes Neutrino `master` (which is still using vue-loader 14 until we have a chance to update to v15),
* prevents the inconsistent situation where the error is fixed on vue-loader v13 and v15, but not v14.