### PR TITLE
fix(v14): prettier default parser removal

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -70,7 +70,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)


### PR DESCRIPTION
same issue steamed down from https://github.com/prettier/prettier/issues/4567 for legacy `vue-loader` version