### PR TITLE
fix(v13): prettier default parser removal

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -77,7 +77,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false })
+      code = prettier.format(code, { semi: false, parser: 'babylon' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)

--- a/lib/template-compiler/modules/transform-require.js
+++ b/lib/template-compiler/modules/transform-require.js
@@ -1,5 +1,7 @@
 // vue compiler module for transforming `<tag>:<attribute>` to `require`
 
+const urlToRequire = require('../url-to-require')
+
 const defaultOptions = {
   video: ['src', 'poster'],
   source: 'src',
@@ -34,19 +36,11 @@ function transform (node, options) {
 
 function rewrite (attr, name) {
   if (attr.name === name) {
-    let value = attr.value
-    const isStatic = value.charAt(0) === '"' && value.charAt(value.length - 1) === '"'
-    if (!isStatic) {
-      return
+    const value = attr.value
+    // only transform static URLs
+    if (value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
+      attr.value = urlToRequire(value.slice(1, -1))
+      return true
     }
-    const firstChar = value.charAt(1)
-    if (firstChar === '.' || firstChar === '~') {
-      if (firstChar === '~') {
-        const secondChar = value.charAt(2)
-        value = '"' + value.slice(secondChar === '/' ? 3 : 2)
-      }
-      attr.value = `require(${value})`
-    }
-    return true
   }
 }

--- a/lib/template-compiler/modules/transform-srcset.js
+++ b/lib/template-compiler/modules/transform-srcset.js
@@ -1,5 +1,7 @@
 // vue compiler module for transforming `img:srcset` to a number of `require`s
 
+const urlToRequire = require('../url-to-require')
+
 module.exports = () => ({
   postTransformNode: node => {
     transform(node)
@@ -41,19 +43,5 @@ function transform (node) {
         attr.value = code
       }
     })
-  }
-}
-
-function urlToRequire (url) {
-  // same logic as in transform-require.js
-  const firstChar = url.charAt(0)
-  if (firstChar === '.' || firstChar === '~') {
-    if (firstChar === '~') {
-      const secondChar = url.charAt(1)
-      url = url.slice(secondChar === '/' ? 2 : 1)
-    }
-    return `require("${url}")`
-  } else {
-    return `"${url}"`
   }
 }

--- a/lib/template-compiler/url-to-require.js
+++ b/lib/template-compiler/url-to-require.js
@@ -1,0 +1,13 @@
+module.exports = function urlToRequire (url) {
+  // same logic as in transform-require.js
+  const firstChar = url.charAt(0)
+  if (firstChar === '.' || firstChar === '~' || firstChar === '@') {
+    if (firstChar === '~') {
+      const secondChar = url.charAt(1)
+      url = url.slice(secondChar === '/' ? 2 : 1)
+    }
+    return `require("${url}")`
+  } else {
+    return `"${url}"`
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-loader",
-  "version": "13.6.2",
+  "version": "13.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-loader",
-  "version": "13.6.2",
+  "version": "13.7.0",
   "description": "Vue single-file component loader for Webpack",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
PR branch was branched out from v13.7.0(latest version of v13).  It seems 13.x branch does not merge back with latest version tag. 

Please advance the 13.x branch to latest v13 version first then merge the change.

Feel free to reject the PR if v13 is out of maintenance cycle. 