### PR TITLE
Module build failed: Error: No parser and no file path given, couldn't infer a parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postcss": "^6.0.8",
     "postcss-load-config": "^1.1.0",
     "postcss-selector-parser": "^2.0.0",
-    "prettier": "^1.7.0",
+    "prettier": "^1.7.0 < 1.13.0",
     "resolve": "^1.4.0",
     "source-map": "^0.6.1",
     "vue-hot-reload-api": "^2.2.0",


### PR DESCRIPTION
Prettier has caused "Module build failed: Error: No parser and no file path given, couldn't infer a parser." in their 1.13.0 update. Downgrade to the previous version to fix this error.