### PR TITLE
Inherit existing queries

### DIFF
--- a/lib/codegen/customBlocks.js
+++ b/lib/codegen/customBlocks.js
@@ -10,7 +10,8 @@ module.exports = function genCustomBlocksCode (
     const src = block.attrs.src || resourcePath
     const attrsQuery = attrsToQuery(block.attrs)
     const issuerQuery = block.attrs.src ? `&issuerPath=${qs.escape(resourcePath)}` : ''
-    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${issuerQuery}${attrsQuery}`
+    const rawQuery = this.resourceQuery.slice(1)
+    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${issuerQuery}${attrsQuery}&${rawQuery}`
     return (
       `import block${i} from ${stringifyRequest(src + query)}\n` +
       `if (typeof block${i} === 'function') block${i}(component)`

--- a/lib/codegen/customBlocks.js
+++ b/lib/codegen/customBlocks.js
@@ -4,14 +4,15 @@ const { attrsToQuery } = require('./utils')
 module.exports = function genCustomBlocksCode (
   blocks,
   resourcePath,
+  resourceQuery,
   stringifyRequest
 ) {
   return `\n/* custom blocks */\n` + blocks.map((block, i) => {
     const src = block.attrs.src || resourcePath
     const attrsQuery = attrsToQuery(block.attrs)
     const issuerQuery = block.attrs.src ? `&issuerPath=${qs.escape(resourcePath)}` : ''
-    const rawQuery = this.resourceQuery.slice(1)
-    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${issuerQuery}${attrsQuery}&${rawQuery}`
+    const inheritQuery = resourceQuery ? `&${resourceQuery.slice(1)}` : ''
+    const query = `?vue&type=custom&index=${i}&blockType=${qs.escape(block.type)}${issuerQuery}${attrsQuery}${inheritQuery}`
     return (
       `import block${i} from ${stringifyRequest(src + query)}\n` +
       `if (typeof block${i} === 'function') block${i}(component)`

--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -20,10 +20,11 @@ module.exports = function genStyleInjectionCode (
   function genStyleRequest (style, i) {
     const src = style.src || resourcePath
     const attrsQuery = attrsToQuery(style.attrs, 'css')
+    const rawQuery = loaderContext.resourceQuery.slice(1)
     // make sure to only pass id when necessary so that we don't inject
     // duplicate tags when multiple components import the same css file
     const idQuery = style.scoped ? `&id=${id}` : ``
-    const query = `?vue&type=style&index=${i}${idQuery}${attrsQuery}`
+    const query = `?vue&type=style&index=${i}${idQuery}${attrsQuery}&${rawQuery}`
     return stringifyRequest(src + query)
   }
 

--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -20,11 +20,11 @@ module.exports = function genStyleInjectionCode (
   function genStyleRequest (style, i) {
     const src = style.src || resourcePath
     const attrsQuery = attrsToQuery(style.attrs, 'css')
-    const rawQuery = loaderContext.resourceQuery.slice(1)
+    const inheritQuery = `&${loaderContext.resourceQuery.slice(1)}`
     // make sure to only pass id when necessary so that we don't inject
     // duplicate tags when multiple components import the same css file
     const idQuery = style.scoped ? `&id=${id}` : ``
-    const query = `?vue&type=style&index=${i}${idQuery}${attrsQuery}&${rawQuery}`
+    const query = `?vue&type=style&index=${i}${idQuery}${attrsQuery}${inheritQuery}`
     return stringifyRequest(src + query)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,9 @@ module.exports = function (source) {
   // module id for scoped CSS & hot-reload
   const shortFilePath = path
     .relative(context, resourcePath)
-    .replace(/^(\.\.[\\\/])+/, '')
+    .replace(/^(\.\.[\\\/])+/, '') +
+    resourceQuery
+
   const id = hash(
     isProduction
       ? (shortFilePath + '\n' + source)

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,6 @@ module.exports = function (source) {
     const scopedQuery = hasScoped ? `&scoped=true` : ``
     const attrsQuery = attrsToQuery(descriptor.template.attrs)
     const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}&${rawQuery}`
-    console.log('template', query)
     const request = templateRequest = stringifyRequest(src + query)
     templateImport = `import { render, staticRenderFns } from ${request}`
   }
@@ -101,7 +100,6 @@ module.exports = function (source) {
     const src = descriptor.script.src || resourcePath
     const attrsQuery = attrsToQuery(descriptor.script.attrs, 'js')
     const query = `?vue&type=script${attrsQuery}&${rawQuery}`
-    console.log('script', query)
     const request = stringifyRequest(src + query)
     scriptImport = (
       `import script from ${request}\n` +
@@ -146,6 +144,7 @@ var component = normalizer(
     code += genCustomBlocksCode(
       descriptor.customBlocks,
       resourcePath,
+      resourceQuery,
       stringifyRequest
     )
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ module.exports = function (source) {
   } = loaderContext
 
   const rawQuery = resourceQuery.slice(1)
+  const inheritQuery = `&${rawQuery}`
   const incomingQuery = qs.parse(rawQuery)
   const options = loaderUtils.getOptions(loaderContext) || {}
 
@@ -89,7 +90,7 @@ module.exports = function (source) {
     const idQuery = `&id=${id}`
     const scopedQuery = hasScoped ? `&scoped=true` : ``
     const attrsQuery = attrsToQuery(descriptor.template.attrs)
-    const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}&${rawQuery}`
+    const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}${inheritQuery}`
     const request = templateRequest = stringifyRequest(src + query)
     templateImport = `import { render, staticRenderFns } from ${request}`
   }
@@ -99,7 +100,7 @@ module.exports = function (source) {
   if (descriptor.script) {
     const src = descriptor.script.src || resourcePath
     const attrsQuery = attrsToQuery(descriptor.script.attrs, 'js')
-    const query = `?vue&type=script${attrsQuery}&${rawQuery}`
+    const query = `?vue&type=script${attrsQuery}${inheritQuery}`
     const request = stringifyRequest(src + query)
     scriptImport = (
       `import script from ${request}\n` +

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,8 @@ module.exports = function (source) {
     resourceQuery
   } = loaderContext
 
-  const incomingQuery = qs.parse(resourceQuery.slice(1))
+  const rawQuery = resourceQuery.slice(1)
+  const incomingQuery = qs.parse(rawQuery)
   const options = loaderUtils.getOptions(loaderContext) || {}
 
   const isServer = target === 'node'
@@ -86,7 +87,8 @@ module.exports = function (source) {
     const idQuery = `&id=${id}`
     const scopedQuery = hasScoped ? `&scoped=true` : ``
     const attrsQuery = attrsToQuery(descriptor.template.attrs)
-    const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}`
+    const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}&${rawQuery}`
+    console.log('template', query)
     const request = templateRequest = stringifyRequest(src + query)
     templateImport = `import { render, staticRenderFns } from ${request}`
   }
@@ -96,7 +98,8 @@ module.exports = function (source) {
   if (descriptor.script) {
     const src = descriptor.script.src || resourcePath
     const attrsQuery = attrsToQuery(descriptor.script.attrs, 'js')
-    const query = `?vue&type=script${attrsQuery}`
+    const query = `?vue&type=script${attrsQuery}&${rawQuery}`
+    console.log('script', query)
     const request = stringifyRequest(src + query)
     scriptImport = (
       `import script from ${request}\n` +

--- a/test/advanced.spec.js
+++ b/test/advanced.spec.js
@@ -28,6 +28,24 @@ test('support chaining with other loaders', done => {
   })
 })
 
+test('inherit queries on files', done => {
+  mockBundleAndRun({
+    entry: 'basic.vue?change',
+    modify: config => {
+      config.module.rules[0] = {
+        test: /\.vue$/,
+        use: [
+          'vue-loader',
+          require.resolve('./mock-loaders/query')
+        ]
+      }
+    }
+  }, ({ module }) => {
+    expect(module.data().msg).toBe('Changed!')
+    done()
+  })
+})
+
 test('expose filename', done => {
   mockBundleAndRun({
     entry: 'basic.vue'

--- a/test/mock-loaders/query.js
+++ b/test/mock-loaders/query.js
@@ -1,0 +1,22 @@
+module.exports = function (content) {
+  const query = this.resourceQuery.slice(1)
+
+  if (/change/.test(query)) {
+    return `
+      <template>
+        <div>Changed!</div>
+      </template>
+      <script>
+      export default {
+        data () {
+          return {
+            msg: 'Changed!'
+          }
+        }
+      }
+      </script>
+    `
+  }
+
+  return content
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,7 +57,7 @@ function bundle (options, cb, wontThrowError) {
     config.module.rules[vueIndex] = Object.assign({}, vueRule, { options: vueOptions })
   }
 
-  if (/\.vue$/.test(config.entry)) {
+  if (/\.vue/.test(config.entry)) {
     const vueFile = config.entry
     config = merge(config, {
       entry: require.resolve('./fixtures/entry'),


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
I am working on a loader that compiles markdown into a Vue component and also extracts all Vue code-blocks into demos. I do this by creating a mddemo-loader that extracts the particular demo by an index passed into the query (eg. `idx=0`). The output of this loader is piped into vue-loader. However, vue-loader currently doesn't inherit the existing queries so the mddemo-loader doesn't get applied (via webpack config) and the entire markdown is gets parsed when vue-loader tries to extract the template and script tags of a particular demo in the markdown file.