### PR TITLE
fix unexpected error when options of cache-loader contains !

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -81,3 +81,7 @@ Compiled the component for usage inside Shadow DOM. In this mode, the styles of 
 - default: `undefined`
 
 When both options are specified, enables file-system-based template compilation caching (requires `cache-loader` to be installed in the same project).
+
+::: tip
+  Interaction between `vue-loader` and `cache-loader` uses [inline loader import syntax](https://webpack.js.org/concepts/loaders/#inline) under the hook, the `!` will be treated as the separator between different loaders, so please ensure `cacheDirectory` doesn't contain `!`.
+:::

--- a/docs/zh/options.md
+++ b/docs/zh/options.md
@@ -81,3 +81,7 @@ sidebar: auto
 - 默认值：`undefined`
 
 当这两个选项同时被设置时，开启基于文件系统的模板编译缓存 (需要在工程里安装 `cache-loader`)。
+
+::: tip 注意
+  在内部，`vue-loader` 和 `cache-loader` 之间的交互使用了 [loader 的内联 import 语法](https://webpack.js.org/concepts/loaders/#inline)，`!` 将会被认为是不同 loaders 之间的分隔符，所以请确保你的 `cacheDirectory` 路径中不包含 `!`。
+:::

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -1,5 +1,6 @@
 const qs = require('querystring')
 const loaderUtils = require('loader-utils')
+const hash = require('hash-sum')
 const selfPath = require.resolve('../index')
 const templateLoaderPath = require.resolve('./templateLoader')
 const stylePostLoaderPath = require.resolve('./stylePostLoader')
@@ -74,7 +75,7 @@ module.exports.pitch = function (remainingRequest) {
     const cacheLoader = cacheDirectory && cacheIdentifier
       ? [`cache-loader?${JSON.stringify({
         cacheDirectory,
-        cacheIdentifier: cacheIdentifier.replace(/!/g, '') + '-vue-loader-template'
+        cacheIdentifier: hash(cacheIdentifier) + '-vue-loader-template'
       })}`]
       : []
     const request = genRequest([

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -74,7 +74,7 @@ module.exports.pitch = function (remainingRequest) {
     const cacheLoader = cacheDirectory && cacheIdentifier
       ? [`cache-loader?${JSON.stringify({
         cacheDirectory,
-        cacheIdentifier: cacheIdentifier + '-vue-loader-template'
+        cacheIdentifier: cacheIdentifier.replace(/!/g, '') + '-vue-loader-template'
       })}`]
       : []
     const request = genRequest([


### PR DESCRIPTION
# Summary

When `cacheIdentifier` contains exclamation mark `!`, the `!` would be treated as the separator between different loaders. which will cause unexpected compilation error.

e.g.

when you have these options set:

```
{
     cacheIdentifier: 'a!a=1'
}
```

You would get following error:

```
Module not found: Error: Can't resolve 'a=1-vue-loader-template"}' in '/Users/haolchen/Documents/__self__/__forked__/vuepress/docs/guide'
 @ ./docs/guide/deploy.md?vue&type=template&id=7ff0bdcd 1:0-324 1:0-324
 @ ./docs/guide/deploy.md
 @ ./lib/app/.temp/routes.js
 @ ./lib/app/app.js
 @ ./lib/app/clientEntry.js
 @ multi ./lib/app/clientEntry.js
```

This PR is to replace all the `!`s in `cacheIdentifier`, and document that `cacheDirectory` path cannot contain `!` (We cannot replace the `!`s in `cacheDirectory`).

refs: https://github.com/vuejs/vuepress/issues/532


## Updated

As Evan's comment, we just `hash` the whole `cacheIdentifier` string.
