### PR TITLE
Fix broken links

### DIFF
--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -2,4 +2,4 @@
 
 - [Vue CLI](https://github.com/vuejs/vue-cli) offers pre-configured unit testing and e2e testing setups.
 
-- If you are interested in manually setting up unit tests for `*.vue` files, consult the docs for [@vue/test-utils](https://vue-test-utils.vuejs.org/en/), which covers setup with [mocha-webpack](https://vue-test-utils.vuejs.org/en/guides/testing-SFCs-with-mocha-webpack.html) or [Jest](https://vue-test-utils.vuejs.org/en/guides/testing-SFCs-with-jest.html).
+- If you are interested in manually setting up unit tests for `*.vue` files, consult the docs for [@vue/test-utils](https://vue-test-utils.vuejs.org), which covers setup with [mocha-webpack](https://vue-test-utils.vuejs.org/guides/testing-SFCs-with-mocha-webpack.html) or [Jest](https://vue-test-utils.vuejs.org/guides/testing-SFCs-with-jest.html).


### PR DESCRIPTION
It looks like the `/en` segment of the url changed, these old links returned 404s