### PR TITLE
feat: #1371 Append the file extension to the mapping files in devtools

### DIFF
--- a/lib/select.js
+++ b/lib/select.js
@@ -1,6 +1,7 @@
 module.exports = function selectBlock (descriptor, loaderContext, query) {
   // template
   if (query.type === `template`) {
+    loaderContext.resourcePath += '.' + (descriptor.template.type || 'template')
     loaderContext.callback(
       null,
       descriptor.template.content,
@@ -11,6 +12,7 @@ module.exports = function selectBlock (descriptor, loaderContext, query) {
 
   // script
   if (query.type === `script`) {
+    loaderContext.resourcePath += '.' + (descriptor.script.lang || 'js')
     loaderContext.callback(
       null,
       descriptor.script.content,
@@ -22,6 +24,7 @@ module.exports = function selectBlock (descriptor, loaderContext, query) {
   // styles
   if (query.type === `style` && query.index != null) {
     const style = descriptor.styles[query.index]
+    loaderContext.resourcePath += '.' + (style.lang || 'css')
     loaderContext.callback(
       null,
       style.content,

--- a/lib/select.js
+++ b/lib/select.js
@@ -1,7 +1,7 @@
 module.exports = function selectBlock (descriptor, loaderContext, query) {
   // template
   if (query.type === `template`) {
-    loaderContext.resourcePath += '.' + (descriptor.template.type || 'template')
+    loaderContext.resourcePath += '.' + (descriptor.template.lang || 'html')
     loaderContext.callback(
       null,
       descriptor.template.content,

--- a/test/style.spec.js
+++ b/test/style.spec.js
@@ -179,6 +179,6 @@ test('CSS Modules', async () => {
   // custom ident
   await testWithIdent(
     '[path][name]---[local]---[hash:base64:5]',
-    /css-modules---red---\w{5}/
+    /css-modules-vue---red---\w{5}/
   )
 })


### PR DESCRIPTION
Improve the debugging experience for `<script>` in the `.vue` file by append the type extensions to the end of files in devtools, to make file locate easier.
Result:
![image](https://user-images.githubusercontent.com/176076/43672304-17b6dff2-9760-11e8-9723-3d79ebc9fe6d.png)
