### PR TITLE
Fix inconsistent path between Windows and POSIX systems‏

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,7 @@ var component = normalizer(
       ? JSON.stringify(filename)
       // Expose the file's full path in development, so that it can be opened
       // from the devtools.
-      : JSON.stringify(rawShortFilePath)
+      : JSON.stringify(rawShortFilePath.replace(/\\/g, '/'))
   }`
 
   code += `\nexport default component.exports`

--- a/test/advanced.spec.js
+++ b/test/advanced.spec.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const { SourceMapConsumer } = require('source-map')
 const normalizeNewline = require('normalize-newline')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
@@ -50,7 +49,7 @@ test('expose file path as __file outside production', done => {
   mockBundleAndRun({
     entry: 'basic.vue'
   }, ({ module }) => {
-    expect(module.__file).toBe(path.normalize('test/fixtures/basic.vue'))
+    expect(module.__file).toBe('test/fixtures/basic.vue')
     done()
   })
 })


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**Did you add tests for your changes?**
Yes, I updated [the existing test](https://github.com/vuejs/vue-loader/blob/0c2da0f5bacb8d0c392fd78b1a3ac72f46bc9ee5/test/advanced.spec.js#L49-L56) to reflect the desired value.

**If relevant, did you update the README?**
No.

**Summary**
When using this loader on a project where we have Windows, Linux (and maybe OS X) users,
I discovered we were getting different bundles if one user bundled using a POSIX system, and another user bundled **the same files** on a Windows system.
I only encountered this issue when building **in development mode**.

**Does this PR introduce a breaking change?**
No.