### PR TITLE
Fix the snapshot testing issue on windows

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -85,7 +85,7 @@ module.exports = function (content) {
     this.options.context ||
     process.cwd()
   const sourceRoot = path.dirname(path.relative(context, filePath))
-  const shortFilePath = path.relative(context, filePath).replace(/^(\.\.[\\\/])+/, '')
+  const shortFilePath = path.relative(context, filePath).replace(/^(\.\.[\\\/])+/, '').replace(/\\/g, '/')
   const moduleId = 'data-v-' + hash(isProduction ? (shortFilePath + '\n' + content) : shortFilePath)
 
   let cssLoaderOptions = ''


### PR DESCRIPTION
Due to the back slash on windows, hash function results different value from mac so the back slash should be replaced with slash consistently.