### PR TITLE
compatible with webpack4 mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const genStylesCode = require('./codegen/styleInjection')
 const { genHotReloadCode } = require('./codegen/hotReload')
 const genCustomBlocksCode = require('./codegen/customBlocks')
 const componentNormalizerPath = require.resolve('./runtime/componentNormalizer')
-const { NS } = require('./plugin')
+const { NS, mode } = require('./plugin')
 
 let errorEmitted = false
 
@@ -55,7 +55,7 @@ module.exports = function (source) {
 
   const isServer = target === 'node'
   const isShadow = !!options.shadowMode
-  const isProduction = options.productionMode || minimize || process.env.NODE_ENV === 'production'
+  const isProduction = options.productionMode || minimize || process.env.NODE_ENV === 'production' || mode.env === 'production'
   const filename = path.basename(resourcePath)
   const context = rootContext || process.cwd()
   const sourceRoot = path.dirname(path.relative(context, resourcePath))

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,6 +3,9 @@ const RuleSet = require('webpack/lib/RuleSet')
 
 const id = 'vue-loader-plugin'
 const NS = 'vue-loader'
+let mode = {
+  env: null
+}
 
 class VueLoaderPlugin {
   apply (compiler) {
@@ -14,6 +17,10 @@ class VueLoaderPlugin {
           loaderContext[NS] = true
         })
       })
+      
+      // Use the webpack mode parameter
+      mode.env = compiler.options.mode
+
     } else {
       // webpack < 4
       compiler.plugin('compilation', compilation => {
@@ -153,4 +160,5 @@ function cloneRule (rule) {
 }
 
 VueLoaderPlugin.NS = NS
+VueLoaderPlugin.mode = mode
 module.exports = VueLoaderPlugin


### PR DESCRIPTION
```javascript
module.exports = {
    mode: 'production'
}
```
Using `mode`  in `webpack4` cannot be obtained by `vue-loader`

`vue-loader/lib/index.js`
```javascript
const isProduction = options.productionMode || minimize || process.env.NODE_ENV === 'production'
```

If you use  `mode` to determine the environment, then `isProduction` cannot catch it. It always is false

---
This pull requests is because #1345  is not safe to make changes
Sorry, I don't know how to make changes on the original pull requests.
