### PR TITLE
fix(templateLoder): honor options.productionMode

### DIFF
--- a/lib/loaders/templateLoader.js
+++ b/lib/loaders/templateLoader.js
@@ -15,7 +15,7 @@ module.exports = function (source) {
   const options = loaderUtils.getOptions(loaderContext) || {}
   const { id } = query
   const isServer = loaderContext.target === 'node'
-  const isProduction = loaderContext.minimize || process.env.NODE_ENV === 'production'
+  const isProduction = options.productionMode || loaderContext.minimize || process.env.NODE_ENV === 'production'
   const isFunctional = query.functional
 
   // allow using custom compiler via options


### PR DESCRIPTION
Like #1208 we need to use `productionMode` option for template loader too.  Related to nuxt/nuxt.js#4002.