### PR TITLE
docs: remove unnecessary `path` module usage

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -37,7 +37,6 @@ A more complete example webpack config will look like this:
 
 ``` js
 // webpack.config.js
-const path = require('path')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {

--- a/docs/ru/guide/README.md
+++ b/docs/ru/guide/README.md
@@ -37,7 +37,6 @@ module.exports = {
 
 ``` js
 // webpack.config.js
-const path = require('path')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {

--- a/docs/zh/guide/README.md
+++ b/docs/zh/guide/README.md
@@ -37,7 +37,6 @@ module.exports = {
 
 ``` js
 // webpack.config.js
-const path = require('path')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {


### PR DESCRIPTION
I guess this is some leftover which is no longer needed.