### PR TITLE
fix: avoid to generate empty css chunk files

### DIFF
--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -1,6 +1,6 @@
 const { attrsToQuery } = require('./utils')
 const hotReloadAPIPath = JSON.stringify(require.resolve('vue-hot-reload-api'))
-const allWhitespaceRE = /^\s+$/
+const nonWhitespaceRE = /\S+/
 
 module.exports = function genStyleInjectionCode (
   loaderContext,
@@ -71,7 +71,7 @@ module.exports = function genStyleInjectionCode (
   }
 
   // filter out empty styles (with no `src` specified or only contains whitespaces)
-  styles = styles.filter(style => style.src || !allWhitespaceRE.test(style.content))
+  styles = styles.filter(style => style.src || nonWhitespaceRE.test(style.content))
   // explicit injection is needed in SSR (for critical CSS collection)
   // or in Shadow Mode (for injection into shadow root)
   // In these modes, vue-style-loader exports objects with the __inject__

--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -1,5 +1,6 @@
 const { attrsToQuery } = require('./utils')
 const hotReloadAPIPath = JSON.stringify(require.resolve('vue-hot-reload-api'))
+const allWhitespaceRE = /^\s+$/
 
 module.exports = function genStyleInjectionCode (
   loaderContext,
@@ -69,6 +70,8 @@ module.exports = function genStyleInjectionCode (
     }
   }
 
+  // filter out empty styles (with no `src` specified or only contains whitespaces)
+  styles = styles.filter(style => style.src || !allWhitespaceRE.test(style.content))
   // explicit injection is needed in SSR (for critical CSS collection)
   // or in Shadow Mode (for injection into shadow root)
   // In these modes, vue-style-loader exports objects with the __inject__

--- a/test/advanced.spec.js
+++ b/test/advanced.spec.js
@@ -137,6 +137,38 @@ test('extract CSS', done => {
   })
 })
 
+test('extract CSS with code spliting', done => {
+  bundle({
+    entry: 'extract-css-chunks.vue',
+    modify: config => {
+      config.module.rules = [
+        {
+          test: /\.vue$/,
+          use: 'vue-loader'
+        },
+        {
+          test: /\.css$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader'
+          ]
+        }
+      ]
+    },
+    plugins: [
+      new MiniCssExtractPlugin({
+        filename: 'test.output.css'
+      })
+    ]
+  }, code => {
+    const css = normalizeNewline(mfs.readFileSync('/test.output.css').toString())
+    expect(css).toContain(`h1 {\n  color: red;\n}`)
+    expect(mfs.existsSync('/empty.test.output.css')).toBe(false)
+    expect(mfs.existsSync('/basic.test.output.css')).toBe(true)
+    done()
+  })
+})
+
 test('support rules with oneOf', async () => {
   const run = (entry, assert) => new Promise((resolve, reject) => {
     mockBundleAndRun({

--- a/test/fixtures/empty-style.vue
+++ b/test/fixtures/empty-style.vue
@@ -1,0 +1,6 @@
+<template>
+  <h1>empty style</h1>
+</template>
+
+<style>
+</style>

--- a/test/fixtures/extract-css-chunks.vue
+++ b/test/fixtures/extract-css-chunks.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <basic></basic>
+    <empty-style></empty-style>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+    Basic: () => import(/* webpackChunkName: "basic" */ './basic.vue'),
+    EmptyStyle: () => import(/* webpackChunkName: "empty" */ './empty-style.vue')
+  }
+}
+</script>
+
+<style>
+h1 {
+  color: red;
+}
+</style>


### PR DESCRIPTION
As addressed in https://github.com/vuejs/vue-cli/issues/3165, do not generate empty chunk css files for component only contains empty style tag.