### PR TITLE
fix: template comments replace windows \ to / confirm consistent hash

### DIFF
--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -112,9 +112,9 @@ module.exports.pitch = function (remainingRequest) {
         // For some reason, webpack fails to generate consistent hash if we
         // use absolute paths here, even though the path is only used in a
         // comment. For now we have to ensure cacheDirectory is a relative path.
-        cacheDirectory: path.isAbsolute(cacheDirectory)
+        cacheDirectory: (path.isAbsolute(cacheDirectory)
           ? path.relative(process.cwd(), cacheDirectory)
-          : cacheDirectory,
+          : cacheDirectory).replace(/\\/g, '/'),
         cacheIdentifier: hash(cacheIdentifier) + '-vue-loader-template'
       })}`]
       : []


### PR DESCRIPTION
Windows will generate different hash because the '\' will be formatter to '//' by `JSON.stringify`
Please fix it to confirm generate consistent hash.
```
// CONCATENATED MODULE: ./node_modules/cache-loader/dist/cjs.js?{"cacheDirectory":"node_modules//.cache//vue-loader",
```