### PR TITLE
Replaced babylon per babel

### DIFF
--- a/lib/template-compiler/index.js
+++ b/lib/template-compiler/index.js
@@ -70,7 +70,7 @@ module.exports = function (html) {
 
     // prettify render fn
     if (!isProduction) {
-      code = prettier.format(code, { semi: false, parser: 'babylon' })
+      code = prettier.format(code, { semi: false, parser: 'babel' })
     }
 
     // mark with stripped (this enables Vue to use correct runtime proxy detection)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "postcss": "^6.0.8",
     "postcss-load-config": "^1.1.0",
     "postcss-selector-parser": "^2.0.0",
-    "prettier": "^1.7.0",
+    "prettier": "^1.16.0",
     "resolve": "^1.4.0",
     "source-map": "^0.6.1",
     "vue-hot-reload-api": "^2.2.0",


### PR DESCRIPTION
babylon has been deprecated... Deprecation message when building:
{ parser: "babylon" } is deprecated; we now treat it as { parser: "babel" }.