### PR TITLE
Docs(EN): Update Preprocessor page to add guidance on SCSS variable sharing.

### DIFF
--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -91,6 +91,36 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
 }
 ```
 
+### Sharing Variables & Mixins via single import
+`sass-resources-loader` in conjunction with `mini-css-extract-plugin` can be used to share variables and mixins across the Vue.js project without having to call an `import` for each component.
+
+```js
+// Require MiniCssExtractPlugin
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+module: {
+  rules: [
+    // CSS & SCSS Processing
+    {
+      test: /\.(sa|sc|c)ss$/,
+      use: [
+        MiniCssExtractPlugin.loader,
+        'css-loader',
+        'postcss-loader',
+        'sass-loader',
+        {
+          loader: 'sass-resources-loader',
+          options: {
+            // Load common SCSS [ Vars & Mixins ]
+            resources: './path/to/shared/variables.scss',
+          },
+        }
+      ],
+    },
+  ]
+},
+```
+
 ## LESS
 
 ``` bash


### PR DESCRIPTION
In response to this issue - https://github.com/vuejs/vue-loader/issues/328

I have added a short guide on the Preprocessor page to guide developers on how they can setup Webpack and Vue to work with a centralized SCSS import.

This will allow developers to access variables and mixins from every component in the project without having to add an import per component. This approach has worked perfectly so far without code duplication and is based on Webpack 4 and MiniCssExtractPlugin.

