### PR TITLE
fix: avoid generating custom block when there is only cache-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.log
 example/dist
 docs/.vuepress/dist
+test/.cache

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -8,6 +8,7 @@ const stylePostLoaderPath = require.resolve('./stylePostLoader')
 const isESLintLoader = l => /(\/|\\|@)eslint-loader/.test(l.path)
 const isNullLoader = l => /(\/|\\|@)null-loader/.test(l.path)
 const isCSSLoader = l => /(\/|\\|@)css-loader/.test(l.path)
+const isCacheLoader = l => /(\/|\\|@)cache-loader/.test(l.path)
 const isPitcher = l => l.path !== __filename
 
 const dedupeESLintLoader = loaders => {
@@ -22,6 +23,23 @@ const dedupeESLintLoader = loaders => {
     }
   })
   return res
+}
+
+const shouldIgnoreCustomBlock = loaders => {
+  const actualLoaders = loaders.filter(loader => {
+    // vue-loader
+    if (loader.path === selfPath) {
+      return false
+    }
+
+    // cache-loader
+    if (isCacheLoader(loader)) {
+      return false
+    }
+
+    return true
+  })
+  return actualLoaders.length === 0
 }
 
 module.exports = code => code
@@ -128,11 +146,9 @@ module.exports.pitch = function (remainingRequest) {
     return `export * from ${request}`
   }
 
-  // if a custom block has no other matching loader other than vue-loader itself,
-  // we should ignore it
-  if (query.type === `custom` &&
-      loaders.length === 1 &&
-      loaders[0].path === selfPath) {
+  // if a custom block has no other matching loader other than vue-loader itself
+  // or cache-loader, we should ignore it
+  if (query.type === `custom` && shouldIgnoreCustomBlock(loaders)) {
     return ``
   }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
+    "cache-loader": "^2.0.1",
     "conventional-changelog-cli": "^1.3.22",
     "css-loader": "^1.0.0",
     "eslint": "^4.19.0",

--- a/test/custom.spec.js
+++ b/test/custom.spec.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const {
   bundle,
   mockBundleAndRun
@@ -68,4 +69,27 @@ test('custom blocks can be ignored', done => {
     expect(code).not.toContain(`describe('example'`)
     done()
   })
+})
+
+test('custom blocks can be ignored even if cache-loader processes them', done => {
+  bundle(
+    {
+      entry: 'custom-language.vue',
+      module: {
+        rules: [
+          {
+            test: /.vue$/,
+            loader: 'cache-loader',
+            options: {
+              cacheDirectory: path.resolve(__dirname, '.cache')
+            }
+          }
+        ]
+      }
+    },
+    code => {
+      expect(code).not.toContain(`describe('example'`)
+      done()
+    }
+  )
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,6 +2410,17 @@ cache-loader@^1.2.2:
     neo-async "^2.5.0"
     schema-utils "^0.4.2"
 
+cache-loader@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cache-loader/-/cache-loader-2.0.1.tgz#5758f41a62d7c23941e3c3c7016e6faeb03acb07"
+  integrity sha512-V99T3FOynmGx26Zom+JrVBytLBsmUCzVG2/4NnUKgvXN4bEV42R1ERl1IyiH/cvFIDA1Ytq2lPZ9tXDSahcQpQ==
+  dependencies:
+    loader-utils "^1.1.0"
+    mkdirp "^0.5.1"
+    neo-async "^2.6.0"
+    normalize-path "^3.0.0"
+    schema-utils "^1.0.0"
+
 call-me-maybe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
@@ -7630,6 +7641,11 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.2.tgz#489105ce7bc54e709d736b195f82135048c50fcc"
   integrity sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==
 
+neo-async@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
+  integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+
 next-tick@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -7811,6 +7827,11 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 normalize-range@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
fix #1394 

I've simply ignored if custom block does not have other loaders than `cache-loader` and `vue-loader`. I'm not sure if there is better way to fix this issue but it just works.