### PR TITLE
Support post loaders for template blocks

### DIFF
--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -10,6 +10,8 @@ const isNullLoader = l => /(\/|\\|@)null-loader/.test(l.path)
 const isCSSLoader = l => /(\/|\\|@)css-loader/.test(l.path)
 const isCacheLoader = l => /(\/|\\|@)cache-loader/.test(l.path)
 const isPitcher = l => l.path !== __filename
+const isPreLoader = l => !l.pitchExecuted
+const isPostLoader = l => l.pitchExecuted
 
 const dedupeESLintLoader = loaders => {
   const res = []
@@ -136,10 +138,15 @@ module.exports.pitch = function (remainingRequest) {
         cacheIdentifier: hash(cacheIdentifier) + '-vue-loader-template'
       })}`]
       : []
+
+    const preLoaders = loaders.filter(isPreLoader)
+    const postLoaders = loaders.filter(isPostLoader)
+
     const request = genRequest([
       ...cacheLoader,
+      ...postLoaders,
       templateLoaderPath + `??vue-loader-options`,
-      ...loaders
+      ...preLoaders
     ])
     // console.log(request)
     // the template compiler uses esm exports

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -305,3 +305,20 @@ test('disable prettify', done => {
     done()
   })
 })
+
+test('postLoaders support', done => {
+  mockBundleAndRun({
+    entry: 'functional-root.vue',
+    module: {
+      rules: [
+        {
+          resourceQuery: /^\?vue&type=template/,
+          enforce: 'post',
+          loader: path.resolve(__dirname, './mock-loaders/js')
+        }
+      ]
+    }
+  }, ({ module }) => {
+    done()
+  })
+})

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -308,17 +308,19 @@ test('disable prettify', done => {
 
 test('postLoaders support', done => {
   mockBundleAndRun({
-    entry: 'functional-root.vue',
+    entry: 'basic.vue',
     module: {
       rules: [
         {
           resourceQuery: /^\?vue&type=template/,
           enforce: 'post',
-          loader: path.resolve(__dirname, './mock-loaders/js')
+          loader: path.resolve(__dirname, './mock-loaders/html')
         }
       ]
     }
   }, ({ module }) => {
+    // class="red" -> { staticClass: "red" } -> { staticClass: "green" }
+    expect(module.render.toString()).toMatch(`green`)
     done()
   })
 })


### PR DESCRIPTION
I know there is already a MR that sorts this issue out but I think bringing the `postLoader` option back is not the best approach to solve this issue. This merge request proposes a solution that allows post loaders to be applied after the template loader with no extra options.

**Motivation**
In our project we would like to be able to execute a custom `babel-macro` in our templates and that requires us to process the compiled template using babel. Currently the v15 does not allow this. See: #1309.

**Description**
The solution implemented in this merge request detects which loaders have `enforce: 'post'` option looking at the `pitchExecuted` flag in the loader object. Once the `VueLoaderPlugin` injects the pitcher at the beginning of the loaders list that means the pitcher's `pitch` would be executed first than any loader. So, every loader which has `pitchExecuted` equals `true` would be a post loader. In that way we can inject the template loader between the post loaders and the rest of them.

Fixes #1309.