### PR TITLE
add regression test for #1491

### DIFF
--- a/test/fixtures/multiple-roots-template.vue
+++ b/test/fixtures/multiple-roots-template.vue
@@ -1,0 +1,4 @@
+<template>
+    <div></div>
+    <div></div>
+</template>

--- a/test/template.spec.js
+++ b/test/template.spec.js
@@ -253,6 +253,16 @@ test('custom compiler directives', done => {
   })
 })
 
+test('multiple roots in template', done => {
+  mockBundleAndRun({
+    entry: 'multiple-roots-template.vue'
+  }, ({ bundleStats }) => {
+    expect(bundleStats.compilation.errors).toHaveLength(1)
+    expect(bundleStats.compilation.errors[0].message).toMatch('should contain exactly one root element')
+    done()
+  }, true)
+})
+
 test('separate loader configuration for template lang and js imports', done => {
   mockBundleAndRun({
     entry: './test/fixtures/template-pre.js',


### PR DESCRIPTION
add regression test for https://github.com/vuejs/vue-loader/issues/1491 "Multiple root nodes throwing RangeError instead of Component template
should contain exactly one root element"


seems the Issue itself is already fixed?
I checked it only with the dependencies of the lock file, maybe they are outdated?

Anyway, I hope the added Test is helpfull