### PR TITLE
fix: id should only depend on file path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,12 +90,7 @@ module.exports = function (source) {
     .replace(/^(\.\.[\/\\])+/, '')
 
   const shortFilePath = rawShortFilePath.replace(/\\/g, '/') + resourceQuery
-
-  const id = hash(
-    isProduction
-      ? (shortFilePath + '\n' + source)
-      : shortFilePath
-  )
+  const id = hash(shortFilePath)
 
   // feature information
   const hasScoped = descriptor.styles.some(s => s.scoped)


### PR DESCRIPTION
Why does `id` depend on `source`?

If `index.js` dynamic imports `a.vue`, `script` in `a.vue` is changed and `style` in `a.vue` is not changed,
the compiled js from `index.js` and compiled css from `a.vue` should not be changed.

But when `id` depend on `source`, the compiled js from `index.js` and compiled css from `a.vue` are changed.