### PR TITLE
 支持自动导入vue文件同级同名的js文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ example/dist
 docs/.vuepress/dist
 test/.cache
 .idea
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 example/dist
 docs/.vuepress/dist
 test/.cache
+.idea

--- a/example/extra-js-component.js
+++ b/example/extra-js-component.js
@@ -1,0 +1,10 @@
+export default {
+  data () {
+    return {
+      msg: 'extra js component'
+    }
+  },
+  created () {
+    window.alert('Loaded.')
+  }
+}

--- a/example/extra-js-component.vue
+++ b/example/extra-js-component.vue
@@ -1,0 +1,7 @@
+<template>
+  <h3>{{msg}}</h3>
+</template>
+
+<style scoped>
+
+</style>

--- a/example/source.js
+++ b/example/source.js
@@ -1,0 +1,12 @@
+
+import ExtraJs from './extra-js-component.vue'
+export default {
+  data () {
+    return {
+      msg: ' 测试 aa'
+    }
+  },
+  components: {
+    ExtraJs
+  }
+}

--- a/example/source.vue
+++ b/example/source.vue
@@ -1,15 +1,20 @@
 <template lang="pug">
 div(ok)
   h1(:class="$style.red") hello
+  p() {{msg}}
+
+  <ExtraJs></ExtraJs>
 </template>
 
 <script>
+
 export default {
   data () {
     return {
       msg: 'fesfff'
     }
   }
+
 }
 </script>
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     publicPath: '/dist/'
   },
   devServer: {
-    stats: "minimal",
+    stats: 'minimal',
     contentBase: __dirname
   },
   module: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const { genHotReloadCode } = require('./codegen/hotReload')
 const genCustomBlocksCode = require('./codegen/customBlocks')
 const componentNormalizerPath = require.resolve('./runtime/componentNormalizer')
 const { NS } = require('./plugin')
+const fs = require('fs')
 
 let errorEmitted = false
 
@@ -27,6 +28,39 @@ function loadTemplateCompiler (loaderContext) {
       ))
     }
   }
+}
+
+function fetchComponentExtraJsFileContent (resourcePath) {
+  if (!resourcePath) {
+    return ''
+  }
+  const hashKey = `component-extra-js-file-content-${hash(resourcePath)}`
+  if (global[hashKey]) {
+    return global[hashKey]
+  }
+  const baseName = path.basename(resourcePath, '.vue')
+  const jsFileName = `${baseName}.js`
+  const jsFilePath = path.resolve(resourcePath, '..', jsFileName)
+  const isValidJsFile = fs.existsSync(jsFilePath)
+  const jsFileContent = isValidJsFile ? `import m from './${jsFileName}';export default m;` : ''
+  return (global[hashKey] = jsFileContent)
+}
+
+function mergeComponentExtraJsFileContent (source, compiler, jsFileContent) {
+  let sourceCopy = source
+  if (jsFileContent.length > 1) {
+    const script = (compiler.parseComponent(source) || {}).script
+    const scriptStart = script && script.start || 0
+    const scriptEnd = script && script.end || 0
+    if (scriptStart >= 0 && scriptEnd > 0) {
+      const tag = 'script'
+      const cropStart = sourceCopy.lastIndexOf(`<${tag}`, scriptStart)
+      const cropEnd = sourceCopy.indexOf(`</${tag}>`, scriptEnd) + tag.length + 3
+      sourceCopy = `${sourceCopy.substr(0, cropStart)}${sourceCopy.substr(cropEnd, sourceCopy.length)}`
+    }
+    sourceCopy = `${sourceCopy}\n<script>${jsFileContent}</script>`
+  }
+  return sourceCopy
 }
 
 module.exports = function (source) {
@@ -64,9 +98,14 @@ module.exports = function (source) {
   const context = rootContext || process.cwd()
   const sourceRoot = path.dirname(path.relative(context, resourcePath))
 
+  const compiler = options.compiler || loadTemplateCompiler(loaderContext)
+
+  const jsFileContent = fetchComponentExtraJsFileContent(resourcePath)
+  const sourceCopy = mergeComponentExtraJsFileContent(source, compiler, jsFileContent)
+
   const descriptor = parse({
-    source,
-    compiler: options.compiler || loadTemplateCompiler(loaderContext),
+    source: jsFileContent.length > 0 ? sourceCopy : source,
+    compiler,
     filename,
     sourceRoot,
     needMap: sourceMap
@@ -85,9 +124,7 @@ module.exports = function (source) {
   }
 
   // module id for scoped CSS & hot-reload
-  const rawShortFilePath = path
-    .relative(context, resourcePath)
-    .replace(/^(\.\.[\/\\])+/, '')
+  const rawShortFilePath = path.relative(context, resourcePath).replace(/^(\.\.[\/\\])+/, '')
 
   const shortFilePath = rawShortFilePath.replace(/\\/g, '/') + resourceQuery
 


### PR DESCRIPTION
如果vue文件同级目录中存在同名的js文件，则会自动导入该js文件作为vue组件的脚本。
如以下目录结构：
```
|--myComponent
  |--demo.vue
  |--demo.js
```
demo.vue在编译时，会自动导入demo.js并替换掉vue文件中的<script>标签内容。

[详细例子](https://github.com/ChangedenCZD/vue-loader/tree/dev-chan/example)