### PR TITLE
types: add loader options declarations

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,40 @@
 import { Plugin } from 'webpack'
+import {
+  CompilerOptions,
+  parseComponent,
+  compile,
+  compileToFunctions,
+  ssrCompile,
+  ssrCompileToFunctions,
+  generateCodeFrame
+} from 'vue-template-compiler'
 
 declare namespace VueLoader {
   class VueLoaderPlugin extends Plugin {}
+
+  interface VueLoaderTemplateCompiler {
+    parseComponent?: typeof parseComponent
+    compile?: typeof compile
+    compileToFunctions?: typeof compileToFunctions
+    ssrCompile?: typeof ssrCompile
+    ssrCompileToFunctions?: typeof ssrCompileToFunctions
+    generateCodeFrame?: typeof generateCodeFrame
+  }
+
+  interface VueLoaderOptions {
+    transformAssetUrls?: { [tag: string]: string | Array<string> }
+    compiler?: VueLoaderTemplateCompiler
+    compilerOptions?: CompilerOptions
+    transpileOptions?: Object
+    optimizeSSR?: boolean
+    hotReload?: boolean
+    productionMode?: boolean
+    shadowMode?: boolean
+    cacheDirectory?: string
+    cacheIdentifier?: string
+    prettify?: boolean
+    exposeFilename?: boolean
+  }
 }
 
 export = VueLoader

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,29 +1,13 @@
 import { Plugin } from 'webpack'
-import {
-  CompilerOptions,
-  parseComponent,
-  compile,
-  compileToFunctions,
-  ssrCompile,
-  ssrCompileToFunctions,
-  generateCodeFrame
-} from 'vue-template-compiler'
+import { VueTemplateCompiler } from '@vue/component-compiler-utils/lib/types'
+import { CompilerOptions } from 'vue-template-compiler'
 
 declare namespace VueLoader {
   class VueLoaderPlugin extends Plugin {}
 
-  interface VueLoaderTemplateCompiler {
-    parseComponent?: typeof parseComponent
-    compile?: typeof compile
-    compileToFunctions?: typeof compileToFunctions
-    ssrCompile?: typeof ssrCompile
-    ssrCompileToFunctions?: typeof ssrCompileToFunctions
-    generateCodeFrame?: typeof generateCodeFrame
-  }
-
   interface VueLoaderOptions {
     transformAssetUrls?: { [tag: string]: string | Array<string> }
-    compiler?: VueLoaderTemplateCompiler
+    compiler?: VueTemplateCompiler
     compilerOptions?: CompilerOptions
     transpileOptions?: Object
     optimizeSSR?: boolean

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "vue-style-loader": "^4.1.0"
   },
   "devDependencies": {
+    "@types/webpack": "^4.4.27",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,11 @@
     "@shellscape/koa-send" "^4.1.0"
     debug "^2.6.8"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
 "@types/babel-types@*", "@types/babel-types@^7.0.0":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/babel-types/-/babel-types-7.0.4.tgz#bfd5b0d0d1ba13e351dff65b6e52783b816826c8"
@@ -788,6 +793,34 @@
   integrity sha512-lyJ8sW1PbY3uwuvpOBZ9zMYKshMnQpXmeDHh8dj9j2nJm/xrW0FgB5gLSYOArj5X0IfaXnmhFoJnhS4KbqIMug==
   dependencies:
     "@types/babel-types" "*"
+
+"@types/node@*":
+  version "11.13.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.7.tgz#85dbb71c510442d00c0631f99dae957ce44fd104"
+  integrity sha512-suFHr6hcA9mp8vFrZTgrmqW2ZU3mbWsryQtQlY/QvwTISCw7nw/j+bCQPPohqmskhmqa5wLNuMHTTsc+xf1MQg==
+
+"@types/tapable@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
+  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack@^4.4.27":
+  version "4.4.27"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.27.tgz#8bb9429185977a6b3b9e6e6132f561066aa7e7c2"
+  integrity sha512-xSll/4UXnLQ0xjdAoTRIFxA6NPC2abJ8nHxRH6SqTymHrfGCc8er7qH0npwCP8q3VFoJh2Hjz1wH8oTjwx9/jQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    source-map "^0.6.0"
 
 "@vue/babel-preset-app@3.0.0-beta.11":
   version "3.0.0-beta.11"


### PR DESCRIPTION
This PR essentially adds the interface `VueLoaderOptions` that can aid type checking
when writting Webpack configuration with Typescript:

```ts
// webpack.config.ts

import { VueLoaderOptions, VueLoaderPlugin } from 'vue-loader'

export default {
  module: {
    rules: {
      // ...
      {
        test: /\.vue$/,
        loader: 'vue-loader',
        options: {
          // * autocompletion available here *
        } as VueLoaderOptions
      }
    }
  },
  plugins: [
    new VueLoaderPlugin()
  ]
}
```

I'm studying the possibility of using a [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#Discriminated-Unions) to assign the `options` type when a match `loader: 'vue-loader'` is found, but this will come in a later PR. For now the casting on the options object is required.

---

Please note the compiler interface use types that were added only in Vue 2.6 (vuejs/vue#7918), but folks with older versions of the template compiler shouldn't experience any errors, they will just not get any type checking on `compile` and `compileOptions` properties.