### PR TITLE
fix getting shadow root when component is functional

### DIFF
--- a/lib/runtime/componentNormalizer.js
+++ b/lib/runtime/componentNormalizer.js
@@ -62,7 +62,12 @@ export default function normalizeComponent (
     options._ssrRegister = hook
   } else if (injectStyles) {
     hook = shadowMode
-      ? function () { injectStyles.call(this, this.$root.$options.shadowRoot) }
+      ? function () {
+        injectStyles.call(
+          this,
+          (options.functional ? this.parent : this).$root.$options.shadowRoot
+        )
+      }
       : injectStyles
   }
 


### PR DESCRIPTION
Add fetching `$root` from parent because functional components' context doesn't have the `$root` property. It will close [issue](https://github.com/vuejs/vue-cli/issues/4097).