### PR TITLE
fix: use "api.isRecorded" instead of "module.hot.data"

### DIFF
--- a/lib/codegen/hotReload.js
+++ b/lib/codegen/hotReload.js
@@ -19,7 +19,7 @@ if (module.hot) {
   api.install(require('vue'))
   if (api.compatible) {
     module.hot.accept()
-    if (!module.hot.data) {
+    if (!api.isRecorded('${id}')) {
       api.createRecord('${id}', component.options)
     } else {
       api.${functional ? 'rerender' : 'reload'}('${id}', component.options)


### PR DESCRIPTION
We should not use `module.hot.data`, which is highly non-reliable. Plugins like [lazy-compile-webpack-plugin](https://github.com/liximomo/lazy-compile-webpack-plugin) use a dummy loader to prevent webpack from building async modules, the module will be compiled and hot-update on demand.  In such a case, the `module.hot.data` is truthy but the record does not exist, which will cause a running error in `api.reload`. I think `api.isRecorded` is more reliable and reasonable.