### PR TITLE
feat: add `defaultModuleName` option for CSS Modules inject name

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -102,3 +102,10 @@ In development mode, we use [prettier](https://prettier.io/) to format the compi
 In non-production environments, vue-loader injects a `__file` property to components for better debugging experience. If the `name` property is missing in a component, Vue will infer it from the `__file` field to display in console warnings.
 
 This property is stripped in production builds by default. But you may want to retain it if you are developing a component library and don't want to bother specifying `name` in each component. Then you can turn this option on.
+
+## defaultModuleName
+
+- type: `string`
+- default: `$style`
+
+When use CSS Modules and set the `module` attribute to `true`, use this option as the name of the component property to inject CSS Modules dynamic class binding.

--- a/docs/zh/options.md
+++ b/docs/zh/options.md
@@ -102,3 +102,10 @@ sidebar: auto
 在非生产环境下，`vue-loader` 会为组件注入一个 `__file` 属性以提升调试体验。如果一个组件没有 `name` 属性，Vue 会通过 `__file` 字段进行推断，并用于控制台警告中的展示。
 
 这个属性在生产环境构建时会被去掉。但如果你在开发一个组件库并且烦于为每个组件设置 `name`，你可能还会想使用它。这时可以把这个选项打开。
+
+## defaultModuleName
+
+- 类型: `string`
+- 默认值: `$style`
+
+当使用 CSS Modules 并且设置 `module` 属性为 `true` 时, 使用这个选项作为组件的属性名来注入 CSS Modules 局部对象。

--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -9,7 +9,8 @@ module.exports = function genStyleInjectionCode (
   resourcePath,
   stringifyRequest,
   needsHotReload,
-  needsExplicitInjection
+  needsExplicitInjection,
+  defaultModuleName
 ) {
   let styleImportsCode = ``
   let styleInjectionCode = ``
@@ -32,7 +33,7 @@ module.exports = function genStyleInjectionCode (
   function genCSSModulesCode (style, request, i) {
     hasCSSModules = true
 
-    const moduleName = style.module === true ? '$style' : style.module
+    const moduleName = style.module === true ? defaultModuleName || '$style' : style.module
     if (cssModuleNames.has(moduleName)) {
       loaderContext.emitError(`CSS module name ${moduleName} is not unique!`)
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,8 @@ module.exports = function (source) {
       resourcePath,
       stringifyRequest,
       needsHotReload,
-      isServer || isShadow // needs explicit injection?
+      isServer || isShadow, // needs explicit injection?
+      options.defaultModuleName
     )
   }
 

--- a/test/style.spec.js
+++ b/test/style.spec.js
@@ -222,3 +222,38 @@ test('CSS Modules Extend', async () => {
     })
   })
 })
+
+test('CSS Modules Default Module Name', done => {
+  mockBundleAndRun({
+    entry: 'css-modules-simple.vue',
+    modify: config => {
+      config.module.rules = [
+        {
+          test: /\.vue$/,
+          loader: 'vue-loader',
+          options: { defaultModuleName: 's' }
+        },
+        {
+          test: /\.css$/,
+          use: [
+            'vue-style-loader',
+            {
+              loader: 'css-loader',
+              options: {
+                modules: true,
+                localIdentName: '[local]_[hash:base64:5]'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }, ({ window, instance }) => {
+    const className = instance.s.red
+    expect(className).toMatch(/^red_\w{5}/)
+    let style = window.document.querySelector('style').textContent
+    style = normalizeNewline(style)
+    expect(style).toContain('.' + className + ' {\n  color: red;\n}')
+    done()
+  })
+})


### PR DESCRIPTION
The default `$style` is too long for write and read.
Custom inject in every file is fussy. 
This pr make it configable.