### PR TITLE
Uses require.resolve

### DIFF
--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -128,7 +128,7 @@ module.exports.pitch = function (remainingRequest) {
   if (query.type === `template`) {
     const path = require('path')
     const cacheLoader = cacheDirectory && cacheIdentifier
-      ? [`cache-loader?${JSON.stringify({
+      ? [`${require.resolve('cache-loader')}?${JSON.stringify({
         // For some reason, webpack fails to generate consistent hash if we
         // use absolute paths here, even though the path is only used in a
         // comment. For now we have to ensure cacheDirectory is a relative path.


### PR DESCRIPTION
Similar to https://github.com/vuejs/vue-cli/pull/4532 - third-parties declaring loaders are strongly advised to use `require.resolve` to ensure they correctly reference their own dependencies.