### PR TITLE
docs: add `sassOptions` for sass-loader >= 8 (#1593) [ci skip]

### DIFF
--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -62,7 +62,9 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
     {
       loader: 'sass-loader',
       options: {
-        indentedSyntax: true
+        sassOptions: {
+          indentedSyntax: true
+        }
       }
     }
   ]

--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -63,7 +63,7 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
       loader: 'sass-loader',
       options: {
         indentedSyntax: true
-        // sass-loader > 8 version
+        // sass-loader version >= 8
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -62,6 +62,8 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
     {
       loader: 'sass-loader',
       options: {
+        indentedSyntax: true
+        // sass-loader > 8 version
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/ru/guide/pre-processors.md
+++ b/docs/ru/guide/pre-processors.md
@@ -62,6 +62,8 @@ module.exports = {
     {
       loader: 'sass-loader',
       options: {
+        indentedSyntax: true
+        // sass-loader > 8
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/ru/guide/pre-processors.md
+++ b/docs/ru/guide/pre-processors.md
@@ -63,7 +63,7 @@ module.exports = {
       loader: 'sass-loader',
       options: {
         indentedSyntax: true
-        // sass-loader > 8
+        // sass-loader >= 8
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/ru/guide/pre-processors.md
+++ b/docs/ru/guide/pre-processors.md
@@ -62,7 +62,9 @@ module.exports = {
     {
       loader: 'sass-loader',
       options: {
-        indentedSyntax: true
+        sassOptions: {
+          indentedSyntax: true
+        }
       }
     }
   ]

--- a/docs/zh/guide/pre-processors.md
+++ b/docs/zh/guide/pre-processors.md
@@ -63,7 +63,7 @@ module.exports = {
       loader: 'sass-loader',
       options: {
         indentedSyntax: true
-        // sass-loader > 8 version
+        // sass-loader version >= 8
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/zh/guide/pre-processors.md
+++ b/docs/zh/guide/pre-processors.md
@@ -62,6 +62,8 @@ module.exports = {
     {
       loader: 'sass-loader',
       options: {
+        indentedSyntax: true
+        // sass-loader > 8 version
         sassOptions: {
           indentedSyntax: true
         }

--- a/docs/zh/guide/pre-processors.md
+++ b/docs/zh/guide/pre-processors.md
@@ -62,7 +62,9 @@ module.exports = {
     {
       loader: 'sass-loader',
       options: {
-        indentedSyntax: true
+        sassOptions: {
+          indentedSyntax: true
+        }
       }
     }
   ]


### PR DESCRIPTION
fix docs with error: 'options has an unknown property 'indentedSyntax'.'
which new sass-loader are writen in 'sassOptions';
This should also cause quick prototyping's sass setting, after executing '$vue serve'