### PR TITLE
docs: Guide to use `::v-deep`

### DIFF
--- a/docs/guide/scoped-css.md
+++ b/docs/guide/scoped-css.md
@@ -62,7 +62,7 @@ The above will be compiled into:
 .a[data-v-f3f3eg9] .b { /* ... */ }
 ```
 
-Some pre-processors, such as Sass, may not be able to parse `>>>` properly. In those cases you can use the `/deep/` or `::v-deep` combinator instead - both are aliases for `>>>` and work exactly the same.
+Some pre-processors, such as Sass, may not be able to parse `>>>` properly. In those cases you can use the `::v-deep` combinator instead - it's an alias for `>>>` and works exactly the same.
 
 ## Dynamically Generated Content
 


### PR DESCRIPTION
Deep Selectors using `/deep/` will no longer work with the latest `vue-loader` that depend on `"@vue/component-compiler-utils": "^3.0.0`, so guide users to use v-deep.