### PR TITLE
Fix Rule.rules (nested rules) not supported

### DIFF
--- a/lib/plugin-webpack4.js
+++ b/lib/plugin-webpack4.js
@@ -146,6 +146,10 @@ function cloneRule (rule) {
     }
   })
 
+  if (rule.rules) {
+    res.rules = rule.rules.map(cloneRule)
+  }
+
   if (rule.oneOf) {
     res.oneOf = rule.oneOf.map(cloneRule)
   }

--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -182,6 +182,10 @@ function cloneRule (rawRule, refs) {
 
   delete res.test
 
+  if (rawRule.rules) {
+    res.rules = rawRule.rules.map(rule => cloneRule(rule, refs))
+  }
+
   if (rawRule.oneOf) {
     res.oneOf = rawRule.oneOf.map(rule => cloneRule(rule, refs))
   }


### PR DESCRIPTION
This PR adds support for [nested rules](https://webpack.js.org/configuration/module/#nested-rules) using [Rule.rules](https://webpack.js.org/configuration/module/#rulerules).