### PR TITLE
Add missing `"repository"` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "url": "https://github.com/vuejs/vue-loader/issues"
   },
   "homepage": "https://github.com/vuejs/vue-loader",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vuejs/vue-loader.git"
+  },
   "gitHooks": {
     "pre-commit": "lint-staged"
   },


### PR DESCRIPTION
Allow user to run `npm repo vue-loader` and remove warn running `npm`.