### PR TITLE
Is the test option of template compiler rule required?

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,7 +66,6 @@ class VueLoaderPlugin implements webpack.Plugin {
     // rule for template compiler
     const templateCompilerRule = {
       loader: require.resolve('./templateLoader'),
-      test: /\.vue$/,
       resourceQuery: (query: string) => {
         const parsed = qs.parse(query.slice(1))
         return parsed.vue != null && parsed.type === 'template'


### PR DESCRIPTION
If the `test` option  of template compiler rule  is removed, some files  like `template.html?vue&type=template` can match the rule, this is expected. So I think the `test` option is not required. 
Also there has some causes that have to use `test`? 