### PR TITLE
feat(templates): allow selecting the compiler per <template>

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,10 +32,16 @@ export { VueLoaderPlugin }
 export interface VueLoaderOptions {
   transformAssetUrls?: SFCTemplateCompileOptions['transformAssetUrls']
   compiler?: TemplateCompiler
-  compilerOptions?: CompilerOptions
+  compilerOptions?: CompilerOptions,
+  templateCompilers?: Record<string, TemplateCompilerOptions>,
   hotReload?: boolean
   exposeFilename?: boolean
   appendExtension?: boolean
+}
+
+export interface TemplateCompilerOptions {
+  compiler: TemplateCompiler,
+  options?: CompilerOptions
 }
 
 let errorEmitted = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,9 @@ export interface VueLoaderOptions {
   appendExtension?: boolean
 }
 
-export type TemplateCompilerOptions = [TemplateCompiler, CompilerOptions]
+export type TemplateCompilerOptions =
+  | TemplateCompiler
+  | [TemplateCompiler, CompilerOptions]
 
 let errorEmitted = false
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,17 +32,14 @@ export { VueLoaderPlugin }
 export interface VueLoaderOptions {
   transformAssetUrls?: SFCTemplateCompileOptions['transformAssetUrls']
   compiler?: TemplateCompiler
-  compilerOptions?: CompilerOptions,
-  templateCompilers?: Record<string, TemplateCompilerOptions>,
+  compilerOptions?: CompilerOptions
+  templateCompilers?: Record<string, TemplateCompilerOptions>
   hotReload?: boolean
   exposeFilename?: boolean
   appendExtension?: boolean
 }
 
-export interface TemplateCompilerOptions {
-  compiler: TemplateCompiler,
-  options?: CompilerOptions
-}
+export type TemplateCompilerOptions = [TemplateCompiler, CompilerOptions]
 
 let errorEmitted = false
 

--- a/src/templateLoader.ts
+++ b/src/templateLoader.ts
@@ -26,13 +26,19 @@ const TemplateLoader: webpack.loader.Loader = function(source, inMap) {
   // Load compiler options from template 'compiler' attribute.
   let compilerOptions = options.compilerOptions
   let compiler = options.compiler
-  if (query.compiler) {
-    const compilerName = query.compiler as string
-    if (
+
+  const compilerName = query.compiler
+  if (compilerName) {
+    if (Array.isArray(compilerName)) {
+      loaderContext.emitError(
+        new Error('You can only specify the compiler attribute once!')
+      )
+    } else if (
       !options.templateCompilers ||
       !options.templateCompilers[compilerName]
     ) {
-      const err = `In your webpack config, specify the vue rule:
+      loaderContext.emitError(
+        new Error(`In your webpack config, specify the vue rule:
         {
           test: /\\.vue$/,
           use: {
@@ -43,12 +49,17 @@ const TemplateLoader: webpack.loader.Loader = function(source, inMap) {
               }
             }
           }
-        }`
-      loaderContext.emitError(new Error(err))
+        }`)
+      )
     } else {
       const info = options.templateCompilers[compilerName]
-      compiler = info[0]
-      compilerOptions = info[1] || {}
+      if (Array.isArray(info)) {
+        compiler = info[0]
+        compilerOptions = info[1] || {}
+      } else {
+        compiler = info
+        compilerOptions = {}
+      }
     }
   }
 

--- a/src/templateLoader.ts
+++ b/src/templateLoader.ts
@@ -24,11 +24,14 @@ const TemplateLoader: webpack.loader.Loader = function(source, inMap) {
   const scopeId = query.scoped ? `data-v-${query.id}` : null
 
   // Load compiler options from template 'compiler' attribute.
-  let compilerOptions = options.compilerOptions;
-  let compiler = options.compiler;
+  let compilerOptions = options.compilerOptions
+  let compiler = options.compiler
   if (query.compiler) {
-    const compilerName = query.compiler as string;
-    if (!options.templateCompilers || !options.templateCompilers[compilerName]) {
+    const compilerName = query.compiler as string
+    if (
+      !options.templateCompilers ||
+      !options.templateCompilers[compilerName]
+    ) {
       const err = `In your webpack config, specify the vue rule:
         {
           test: /\\.vue$/,
@@ -36,16 +39,16 @@ const TemplateLoader: webpack.loader.Loader = function(source, inMap) {
             loader: 'vue-loader',
             options: {
               templateCompilers: {
-                ${compilerName}: {compiler: require('${compilerName}'), compilerOptions: {}}
+                ${compilerName}: [require('${compilerName}'), {}]
               }
             }
           }
-        }`;
+        }`
       loaderContext.emitError(new Error(err))
     } else {
       const info = options.templateCompilers[compilerName]
-      compiler = info.compiler
-      compilerOptions = info.options || {}
+      compiler = info[0]
+      compilerOptions = info[1] || {}
     }
   }
 


### PR DESCRIPTION
This is to allow multiple renderers to be used within the same Vue app. In particular, I am building a WebGL/Canvas2d renderer for the vue3 api. It enables the developer to write a part of the app in HTML DOM, and another part in WebGL.

Example usage:
webpack.config.js:
```javascript
      {
        test: /\.vue$/,
        use: {
          loader: 'vue-loader',
          options: {
            templateCompilers: {
              vugel: {compiler: require('vugel'), compilerOptions: {}}
            }
          }
        }
```

Comp.vue:
```html
<template compiler="vugel">
  <node :scale="prop">
    <rect v-for="(item,index) in images" :x="item.x" :w="item.w" :y="index * 40" :h="20" :color="0xff00ffff">
    </rect>
  </node>
</template>
```