### PR TITLE
fix minor problems

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path')
 const hash = require('hash-sum')
 const VueLoaderPlugin = require('../dist/plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 
 module.exports = (env = {}) => {
   const isProd = env.prod
@@ -86,7 +87,8 @@ module.exports = (env = {}) => {
       new VueLoaderPlugin(),
       new MiniCssExtractPlugin({
         filename: '[name].css'
-      })
+      }),
+      new CleanWebpackPlugin()
     ],
     optimization: {
       minimize

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsc --watch",
     "build": "tsc",
     "dev-example": "webpack-dev-server --config example/webpack.config.js --inline --hot",
-    "build-example": "rm -rf example/dist && webpack --config example/webpack.config.js --env.prod",
+    "build-example": "webpack --config example/webpack.config.js --env.prod",
     "lint": "prettier --write --parser typescript \"src/**/*.ts\"",
     "prepublishOnly": "tsc"
   },
@@ -46,6 +46,7 @@
     "@vue/compiler-sfc": "^3.0.0-alpha.1",
     "babel-loader": "^8.0.6",
     "cache-loader": "^4.1.0",
+    "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.3.2",
     "file-loader": "^5.0.2",
     "jest": "^24.9.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   parse,
   TemplateCompiler,
   CompilerOptions,
+  CompilerError,
   SFCBlock,
   SFCTemplateCompileOptions,
   SFCStyleBlock
@@ -82,7 +83,7 @@ const loader: webpack.loader.Loader = function(source: string) {
   })
 
   if (errors.length) {
-    errors.forEach(err => {
+    errors.forEach((err: CompilerError) => {
       formatError(err, source, resourcePath)
       loaderContext.emitError(err)
     })
@@ -109,7 +110,7 @@ const loader: webpack.loader.Loader = function(source: string) {
   const id = hash(isProduction ? shortFilePath + '\n' + source : shortFilePath)
 
   // feature information
-  const hasScoped = descriptor.styles.some(s => s.scoped)
+  const hasScoped = descriptor.styles.some((s: SFCStyleBlock) => s.scoped)
   const needsHotReload =
     !isServer &&
     !isProduction &&
@@ -207,7 +208,7 @@ const loader: webpack.loader.Loader = function(source: string) {
     code += `\n/* custom blocks */\n`
     code +=
       descriptor.customBlocks
-        .map((block, i) => {
+        .map((block: SFCBlock, i: number) => {
           const src = block.attrs.src || resourcePath
           const attrsQuery = attrsToQuery(block.attrs)
           const blockTypeQuery = `&blockType=${qs.escape(block.type)}`

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -45,7 +45,7 @@ class VueLoaderPlugin implements webpack.Plugin {
     const vueUse = vueRule.use as webpack.RuleSetLoader[]
     // get vue-loader options
     const vueLoaderUseIndex = vueUse.findIndex(u => {
-      return /^vue-loader|(\/|\\|@)vue-loader/.test(u.loader || '')
+      return /^vue-loader|([\/\\@])vue-loader/.test(u.loader || '')
     })
 
     if (vueLoaderUseIndex < 0) {
@@ -143,10 +143,8 @@ function cloneRule(rule: webpack.RuleSetRule) {
       if (resource && !resource(fakeResourcePath)) {
         return false
       }
-      if (resourceQuery && !resourceQuery(query)) {
-        return false
-      }
-      return true
+
+      return !(resourceQuery && !resourceQuery(query))
     }
   }
 
@@ -182,10 +180,7 @@ function cloneRuleForRenderFn(rule: webpack.RuleSetRule) {
       if (resource && !resource(fakeResourcePath)) {
         return false
       }
-      if (resourceQuery && !resourceQuery(query)) {
-        return false
-      }
-      return true
+      return !(resourceQuery && !resourceQuery(query))
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,6 +994,18 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
+"@types/webpack@^4.4.31":
+  version "4.41.7"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.7.tgz#22be27dbd4362b01c3954ca9b021dbc9328d9511"
+  integrity sha512-OQG9viYwO0V1NaNV7d0n79V+n6mjOV30CwgFPIfTzwmk8DHbt+C4f2aBGdCYbo3yFyYD6sjXfqqOjwkl1j+ulA==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
+
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"
@@ -2080,6 +2092,14 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+
+clean-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz#a99d8ec34c1c628a4541567aa7b457446460c62b"
+  integrity sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==
+  dependencies:
+    "@types/webpack" "^4.4.31"
+    del "^4.1.1"
 
 cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
1. add types
2. the `rm` command is not working in Windows OS (so use clean-webpack-plugin Instead)
3. 
```
if(a === 'b') {
  return true
}
return false
```
can be
```
return a === 'b'
```

4. `\/|\\|@` can be `([\/\\@])`

5. the Loader can be 'string' also
