### PR TITLE
bug: (next) Missing line break before const cssModules causes module load error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ const loader: webpack.loader.Loader = function(source: string) {
       const styleRequest = stringifyRequest(src + query)
       if (style.module) {
         if (!hasCSSModules) {
-          stylesCode += `const cssModules = script.__cssModules = {}`
+          stylesCode += `\nconst cssModules = script.__cssModules = {}`
           hasCSSModules = true
         }
         stylesCode += genCSSModulesCode(


### PR DESCRIPTION
Hi!

Fixes an edge case: if you have multiple `style` and the *2nd* one is a `module`, it will cause a build failure:

```
<style lang="css">
</style>

<style module>
</style>
```

Internally, this builds:

```js
import "./App.vue?vue&type=style&index=0&lang=css"const cssModules = script.__cssModules = {}
import style1 from "./App.vue?vue&type=style&index=1&module=true&lang=css"
cssModules["$style"] = style1
```

Notice the missing line break before `const cssModules =`.

Apologies for no test... but I can't seem to find any for `next` :).

Cheers!