### PR TITLE
fix: do not require vue extension for template loader

### DIFF
--- a/src/pluginWebpack4.ts
+++ b/src/pluginWebpack4.ts
@@ -67,7 +67,6 @@ class VueLoaderPlugin implements webpack.Plugin {
     // rule for template compiler
     const templateCompilerRule = {
       loader: require.resolve('./templateLoader'),
-      test: /\.vue$/,
       resourceQuery: (query: string) => {
         const parsed = qs.parse(query.slice(1))
         return parsed.vue != null && parsed.type === 'template'

--- a/src/pluginWebpack5.ts
+++ b/src/pluginWebpack5.ts
@@ -159,7 +159,6 @@ class VueLoaderPlugin {
     // rule for template compiler
     const templateCompilerRule = {
       loader: require.resolve('./templateLoader'),
-      test: /\.vue$/,
       resourceQuery: (query: string) => {
         const parsed = qs.parse(query.slice(1))
         return parsed.vue != null && parsed.type === 'template'


### PR DESCRIPTION
### Background

I'm developing a prototype of vuepress-next

For `.md` files, the template loader won't take effect with `test: /\.vue$/`.

### Alternative

Add an option for `VueLoaderPlugin` to make the test rule customizable.