### PR TITLE
fix(next): use `export = xxx` instead of `exports.xxx`

### DIFF
--- a/src/pitcher.ts
+++ b/src/pitcher.ts
@@ -125,4 +125,4 @@ function shouldIgnoreCustomBlock(loaders: Loader[]) {
   return actualLoaders.length === 0
 }
 
-export default pitcher
+export = pitcher

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,4 +14,4 @@ if (webpack.version && webpack.version[0] > '4') {
   Plugin = require('./pluginWebpack4').default
 }
 
-export default Plugin
+export = Plugin


### PR DESCRIPTION
fix https://github.com/vuejs/vue-next/issues/1229

## Bug Reson
webpack import module by node solution and caused `pitcher` isn't loaded. 
This can be fix by node `exports.xxx`  === ts `export = xxx`.