### PR TITLE
fix: skip matching rules with 'enforce'

### DIFF
--- a/src/pluginWebpack5.ts
+++ b/src/pluginWebpack5.ts
@@ -96,7 +96,10 @@ class VueLoaderPlugin implements Plugin {
     let vueRules: Effect[] = []
 
     for (const rawRule of rules) {
-      // skip the `include` check when locating the vue rule
+      // skip rules with 'enforce'. eg. rule for eslint-loader
+      if (rawRule.enforce) {
+        continue
+      }
       vueRules = match(rawRule, 'foo.vue')
       if (!vueRules.length) {
         vueRules = match(rawRule, 'foo.vue.html')


### PR DESCRIPTION
skip matching rules with 'enforce'.
eg. the rule of eslint-loader is before the rule of vue-loader, will throw this error: '[VueLoaderPlugin Error] No matching rule for .vue files found.'