### PR TITLE
fix(readme): add style-loader in rules

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -73,6 +73,7 @@ module.exports = {
         test: /\.css$/,
         use: [
           'vue-style-loader',
+          'style-loader',
           'css-loader'
         ]
       }


### PR DESCRIPTION
I know this may seem redundant having a style-loader under
vue-style-loader. But I have been facing this issue for quite awhile,
and even made a post about the incident on Vue Forms.

Please check out the form for more information.

https://forum.vuejs.org/t/style-tag-in-vue-template-not-working/100539
