### PR TITLE
fix: Fix id differences between different operating systems

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ module.exports = function (source) {
 
   const id = hash(
     isProduction
-      ? (shortFilePath + '\n' + source)
+      ? (shortFilePath + '\n' + source.replace(/\r\n/g, '\n'))
       : shortFilePath
   )
 


### PR DESCRIPTION
Id will affect the hash calculation of webpack, thus affecting the final cache