### PR TITLE
fix: updated pre-processors.md to warn about global imports

### DIFF
--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -95,6 +95,8 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
   ]
 }
 ```
+**Pay attention**: this makes the variables & files accessable in all Vue components in the project, increasing the bundle size significantly (based on the amount of variables/ files you add in the prependData).
+
 
 ## LESS
 


### PR DESCRIPTION
prependData and it's predecessor ``` data ``` both include all variables and files. In previous projects, we've run accros bundle sizes for CSS files that saw a 20x decrease when these variables / files were cleaned up, limiting the repeated shared CSS. Without carefull use, this will result in specific CSS being included in all the individual components. This simple addition to the docs might warn some people and prevent their project size from increasing unnecessarily.