### PR TITLE
docs: 'prependData' option renamed to 'additionalData' in sass-loader 9

### DIFF
--- a/docs/guide/pre-processors.md
+++ b/docs/guide/pre-processors.md
@@ -75,7 +75,7 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
 
 ### Sharing Global Variables
 
-`sass-loader` also supports a `prependData` option which allows you to share common variables among all processed files without having to explicit import them:
+`sass-loader` also supports a `additionalData` option which allows you to share common variables among all processed files without having to explicit import them:
 
 ``` js
 // webpack.config.js -> module.rules
@@ -88,8 +88,9 @@ Note that `sass-loader` processes the non-indent-based `scss` syntax by default.
       loader: 'sass-loader',
       options: {
         // you can also read from a file, e.g. `variables.scss`
-        // use `data` here if sass-loader version < 8
-        prependData: `$color: red;`
+        // use `prependData` here if sass-loader version = 8, or
+        // `data` if sass-loader version < 8
+        additionalData: `$color: red;`
       }
     }
   ]

--- a/docs/ru/guide/pre-processors.md
+++ b/docs/ru/guide/pre-processors.md
@@ -88,8 +88,9 @@ module.exports = {
       loader: 'sass-loader',
       options: {
         // вы можете также указать файл, например `variables.scss`
+        // используйте свойство `prependData` здесь, если версия sass-loader = 8
         // используйте свойство `data` здесь, если версия sass-loader < 8
-        prependData: `$color: red;`
+        additionalData: `$color: red;`
       }
     }
   ]

--- a/docs/zh/guide/pre-processors.md
+++ b/docs/zh/guide/pre-processors.md
@@ -88,8 +88,9 @@ module.exports = {
       loader: 'sass-loader',
       options: {
         // 你也可以从一个文件读取，例如 `variables.scss`
+        // 如果 sass-loader 版本 = 8，这里使用 `prependData` 字段
         // 如果 sass-loader 版本 < 8，这里使用 `data` 字段
-        prependData: `$color: red;`
+        additionalData: `$color: red;`
       }
     }
   ]


### PR DESCRIPTION
Option `prependData `should be renamed `additionalData` in `vue.config.js` as per [sass-loader v9.0.0 changelog](https://github.com/webpack-contrib/sass-loader/releases/tag/v9.0.0) and corresponding [doc](https://github.com/webpack-contrib/sass-loader#additionaldata).