### PR TITLE
fix: fix script bindings should not be a  undefined value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ export default function loader(
     const scopedQuery = hasScoped ? `&scoped=true` : ``
     const attrsQuery = attrsToQuery(descriptor.template.attrs)
     const bindingsQuery = script
-      ? `&bindings=${JSON.stringify(script.bindings)}`
+      ? `&bindings=${JSON.stringify(script.bindings ?? {})}`
       : ``
     const query = `?vue&type=template${idQuery}${scopedQuery}${attrsQuery}${bindingsQuery}${resourceQuery}`
     templateRequest = stringifyRequest(src + query)


### PR DESCRIPTION
when bindings pass as a query string, should not be `"undefined"` string value.