### PR TITLE
fix: set default render when template is empty

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,7 @@ export default function loader(
 
   // template
   const renderFnName = isServer ? `ssrRender` : `render`
+  const renderReplace = `script.${renderFnName} = ${renderFnName}`
   let templateImport = `const ${renderFnName} = () => {}`
   let templateRequest
   if (descriptor.template) {
@@ -197,12 +198,7 @@ export default function loader(
     })
   }
 
-  let code = [
-    templateImport,
-    scriptImport,
-    stylesCode,
-    templateImport ? `script.${renderFnName} = ${renderFnName}` : ``,
-  ]
+  let code = [templateImport, scriptImport, stylesCode, renderReplace]
     .filter(Boolean)
     .join('\n')
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,9 +150,9 @@ export default function loader(
   }
 
   // template
-  let templateImport = ``
-  let templateRequest
   const renderFnName = isServer ? `ssrRender` : `render`
+  let templateImport = `const ${renderFnName} = () => {}`
+  let templateRequest
   if (descriptor.template) {
     const src = descriptor.template.src || resourcePath
     const idQuery = `&id=${id}`

--- a/test/fixtures/template-empty.vue
+++ b/test/fixtures/template-empty.vue
@@ -1,0 +1,1 @@
+<template></template>

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -102,3 +102,24 @@ test('postLoaders support', async () => {
   // class="red" -> class="green"
   expect(instance.$el.className).toBe('green')
 })
+
+test('empty template', async () => {
+  const { componentModule } = await mockBundleAndRun({
+    entry: 'template-empty.vue',
+  })
+
+  expect(componentModule.render).not.toBeUndefined()
+  expect(componentModule.render()).toBeUndefined()
+  expect(componentModule.ssrRender).toBeUndefined()
+})
+
+test('empty template with ssr', async () => {
+  const { componentModule } = await mockBundleAndRun({
+    entry: 'template-empty.vue',
+    target: 'node',
+  })
+
+  expect(componentModule.ssrRender).not.toBeUndefined()
+  expect(componentModule.ssrRender()).toBeUndefined()
+  expect(componentModule.render).toBeUndefined()
+})


### PR DESCRIPTION
`@vue/compiler-sfc` will return `null` if `<template>` is empty, so we need default render to handle it.

https://github.com/vuejs/vue-next/blob/f4621ff5ee4abe924d985177956af3ddc9bb378f/packages/compiler-sfc/__tests__/parse.spec.ts#L114-L119

Also, this is also handled by `rollup-plugin-vue`:

https://github.com/vuejs/rollup-plugin-vue/blob/6960203fdc4285b4322a2c4f061f4a2773d49c9c/src/index.ts#L469

Without this default render, it would cause "Component is missing template or render function" warning