### PR TITLE
Fix missing default export error

### DIFF
--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -120,7 +120,9 @@ module.exports.pitch = function (remainingRequest) {
         ...beforeLoaders
       ])
       // console.log(request)
-      return `import mod from ${request}; export default mod; export * from ${request}`
+      return query.module
+        ? `export { default } from  ${request}; export * from ${request}`
+        : `export * from ${request}`
     }
   }
 


### PR DESCRIPTION
In webpack 5 + mini-css-extract-plugin you'll see warning about a missing default export. This happens because vue-loader always assumes a default export for style blocks. This only happens in the case of CSS modules.

Closes #1742