### PR TITLE
[next] Fix missing default export error

### DIFF
--- a/src/pitcher.ts
+++ b/src/pitcher.ts
@@ -68,7 +68,8 @@ export const pitch = function () {
       const beforeLoaders = loaders.slice(cssLoaderIndex + 1)
       return genProxyModule(
         [...afterLoaders, stylePostLoaderPath, ...beforeLoaders],
-        context
+        context,
+        !! query.module
       )
     }
   }


### PR DESCRIPTION
In webpack 5 + mini-css-extract-plugin you'll see warning about a missing default export. This happens because vue-loader always assumes a default export for style blocks. This only happens in the case of CSS modules.

This is the same as #1748 but for vue-loader 16