### PR TITLE
fix: ensure new webpack5 generator property in rules passes ruleset checks (v15)

### DIFF
--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -20,6 +20,7 @@ const ruleSetCompiler = new RuleSetCompiler([
   new BasicEffectRulePlugin('sideEffects'),
   new BasicEffectRulePlugin('parser'),
   new BasicEffectRulePlugin('resolve'),
+  new BasicEffectRulePlugin('generator'),
   new UseEffectRulePlugin()
 ])
 


### PR DESCRIPTION
Webpack 5 has a new property in rule definitions called `generator` - we need to account for that in the rule validiations we have in place.

**Note** this is for vue-loader 15, targeting Vue 2. Matching PR for v16: https://github.com/vuejs/vue-loader/pull/1754

## Tests

I wasn't sure how to test for this as the repo's webpack version is locked to v4, and the property only exists in v5.

I locally changed the webpack version to v5, added the following rule to the test cases base config and ran the tests:

```js
{
  test: /\.tiff$/,
  type: 'asset/resource',
  generator: {
    filename: '[hash][ext][query]'
  }
}
```

... multiple tests broke without my change, and all tests passed after my change.


close #1729