### PR TITLE
fix: ensure new webpack5 generator property in rules passes ruleset checks (v16)

### DIFF
--- a/src/pluginWebpack5.ts
+++ b/src/pluginWebpack5.ts
@@ -74,6 +74,7 @@ const ruleSetCompiler = new RuleSetCompiler([
   new BasicEffectRulePlugin('sideEffects'),
   new BasicEffectRulePlugin('parser'),
   new BasicEffectRulePlugin('resolve'),
+  new BasicEffectRulePlugin('generator'),
   new UseEffectRulePlugin(),
 ])
 


### PR DESCRIPTION
Webpack 5 has a new property in rule definitions called `generator` - we need to account for that in the rule validiations we have in place.

**Note** this is for vue-loader 16, targeting Vue 3. Matching PR for v15: https://github.com/vuejs/vue-loader/pull/1753

## Tests

I wasn't able to test this with v16, as the repo is locked to webpack v4, and switching tempararily to webpack 5 breaks everything as the type imports for webpack no longer work/match.

Since I could verify the change on the other PR for v15, this should be safe to merge.


close #1729