### PR TITLE
feat: allow manualyl specifying whether server-rendering is targeted

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ export interface VueLoaderOptions {
   hotReload?: boolean
   exposeFilename?: boolean
   appendExtension?: boolean
+
+  isServerBuild?: boolean
 }
 
 let errorEmitted = false
@@ -85,7 +87,7 @@ export default function loader(
   const options = (loaderUtils.getOptions(loaderContext) ||
     {}) as VueLoaderOptions
 
-  const isServer = target === 'node'
+  const isServer = options.isServerBuild ?? target === 'node'
   const isProduction = mode === 'production'
 
   const { descriptor, errors } = parse(source, {

--- a/src/resolveScript.ts
+++ b/src/resolveScript.ts
@@ -33,7 +33,7 @@ export function resolveScript(
   }
 
   const isProd = loaderContext.mode === 'production'
-  const isServer = loaderContext.target === 'node'
+  const isServer = options.isServerBuild ?? loaderContext.target === 'node'
   const enableInline = canInlineTemplate(descriptor, isProd)
 
   const cacheToUse = isServer ? serverCache : clientCache

--- a/src/templateLoader.ts
+++ b/src/templateLoader.ts
@@ -20,7 +20,7 @@ const TemplateLoader: webpack.loader.Loader = function (source, inMap) {
   const options = (loaderUtils.getOptions(loaderContext) ||
     {}) as VueLoaderOptions
 
-  const isServer = loaderContext.target === 'node'
+  const isServer = options.isServerBuild ?? loaderContext.target === 'node'
   const isProd = loaderContext.mode === 'production'
   const query = qs.parse(loaderContext.resourceQuery.slice(1))
   const scopeId = query.id as string


### PR DESCRIPTION
This option provides a possible fix for #1734

When testing with mocha + mochapack, even though the target
environment is `node`, the compiled component is expected to be run
with `jsdom` rather than with a Node.js server, so it should still be
a client bundle.