### PR TITLE
feat: option to filter style tags from callback

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,8 @@ declare namespace VueLoader {
     cacheDirectory?: string
     cacheIdentifier?: string
     prettify?: boolean
-    exposeFilename?: boolean
+    exposeFilename?: boolean,
+    filterStyleTag?: (styleTagAttributes: Object) => boolean,
   }
 }
 

--- a/lib/loaders/pitcher.js
+++ b/lib/loaders/pitcher.js
@@ -50,7 +50,7 @@ module.exports = code => code
 // and transform it into appropriate requests.
 module.exports.pitch = function (remainingRequest) {
   const options = loaderUtils.getOptions(this)
-  const { cacheDirectory, cacheIdentifier } = options
+  const { cacheDirectory, cacheIdentifier, filterStyleTag } = options
   const query = qs.parse(this.resourceQuery.slice(1))
 
   let loaders = this.loaders
@@ -110,6 +110,10 @@ module.exports.pitch = function (remainingRequest) {
 
   // Inject style-post-loader before css-loader for scoped CSS and trimming
   if (query.type === `style`) {
+    // If filterStyleTag function is provided, check that it's truthy for this query or ignore it
+    if (typeof filterStyleTag === 'function' && !filterStyleTag(query)) {
+      return ''
+    }
     const cssLoaderIndex = loaders.findIndex(isCSSLoader)
     if (cssLoaderIndex > -1) {
       const afterLoaders = loaders.slice(0, cssLoaderIndex + 1)

--- a/lib/plugin-webpack4.js
+++ b/lib/plugin-webpack4.js
@@ -85,7 +85,8 @@ class VueLoaderPlugin {
       },
       options: {
         cacheDirectory: vueLoaderUse.options.cacheDirectory,
-        cacheIdentifier: vueLoaderUse.options.cacheIdentifier
+        cacheIdentifier: vueLoaderUse.options.cacheIdentifier,
+        filterStyleTag: vueLoaderUse.options.filterStyleTag
       }
     }
 

--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -126,7 +126,8 @@ class VueLoaderPlugin {
       },
       options: {
         cacheDirectory: vueLoaderUse.options.cacheDirectory,
-        cacheIdentifier: vueLoaderUse.options.cacheIdentifier
+        cacheIdentifier: vueLoaderUse.options.cacheIdentifier,
+        filterStyleTag: vueLoaderUse.options.filterStyleTag
       }
     }
 

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -174,3 +174,38 @@ test('cloned rules should not intefere with each other', done => {
     done()
   })
 })
+
+test('ignore style tags', done => {
+  mockBundleAndRun({
+    entry: 'style-dynamic.vue',
+    modify: config => {
+      config.module.rules = [
+        {
+          test: /\.vue$/,
+          loader: 'vue-loader',
+          options: {
+            filterStyleTag: ({ keep }) => {
+              return keep
+            }
+          }
+        },
+        {
+          oneOf: [
+            {
+              test: /\.css$/,
+              use: ['vue-style-loader', 'css-loader']
+            }
+          ]
+        }
+      ]
+    }
+  }, ({ window, module }) => {
+    mockRender(module)
+
+    let style = window.document.querySelector('style').textContent
+    style = normalizeNewline(style)
+    expect(style).toContain(`h2[${module._scopeId}] {\n  color: orange;\n}`)
+    expect(style).not.toContain(`color: cyan;`)
+    done()
+  })
+})

--- a/test/fixtures/style-dynamic.vue
+++ b/test/fixtures/style-dynamic.vue
@@ -1,0 +1,25 @@
+<template>
+  <h2>{{msg}}</h2>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      msg: 'Hello from themed styled Component!'
+    }
+  }
+}
+</script>
+
+<style scoped>
+h2 {
+  color: cyan;
+}
+</style>
+
+<style scoped keep>
+h2 {
+  color: orange;
+}
+</style>


### PR DESCRIPTION
I needed a way to write multiple `<style>` tags on my components, but to only apply (i.e. bundle) them conditionally.

## The feature I was looking for

> This is a dummy example, just here to illustrate.

Let's say the style depends on the current season:

```vue
<template>
  <p>Hello vue-loader team!</p>
</template>

<style scoped theme="winter">
  p { color: cyan; }
</style>

<style scoped theme="corporate">
  p { color: orange; } 
</style>
```

And we select the correct style tag depending on an environment variable (`process.env.theme === 'summer'`).

> I know there are other way to achieve the same thing, but it looked more elegant this way, and it may reduce the bundle size at the end, compared to the others solutions I came up with:
>  - using css preprocessor conditions: painful to maintain, bad code readability
>  - css variables: not fully supported by IE
>  - Load different css file according the condition result: can't use scoped style, so overriding css is painful to write

## Usage example

```javascript
{
   test: /\.vue$/,
   loader: 'vue-loader',
   options: {
      filterStyleTag: ({ theme }) => {
         return theme === process.env.theme
      }
   }
}
```

We can declare a new option with a callback that take the inner "query" parsed from the style tag.   
It is supposed to be used like the `Array.prototype.filter` method: return `true` to keep the style tag. `false` will ignore the style tag.

**Let me know what you think!**  
Is it a bad idea to do something like this? Will it break anything I didn't see? Can my feature be improved?