### PR TITLE
feat: allow specifying pad when using @vue/compiler-sfc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export interface VueLoaderOptions {
   appendExtension?: boolean
 
   isServerBuild?: boolean
+  pad?: boolean | 'line' | 'space'
 }
 
 let errorEmitted = false
@@ -89,11 +90,13 @@ export default function loader(
 
   const isServer = options.isServerBuild ?? target === 'node'
   const isProduction = mode === 'production'
+  const pad = options.pad ?? sourceMap
 
   const filename = resourcePath.replace(/\?.*$/, '')
   const { descriptor, errors } = parse(source, {
     filename,
     sourceMap,
+    pad,
   })
 
   // cache descriptor


### PR DESCRIPTION
Adds the ability to specify the `pad` mode when calling `parse` in `@vue/compiler-sfc`. This is required for accurate source maps otherwise templates are compiled without the leading new lines until `<script>` is encountered.

Closes https://github.com/vuejs/vue-loader/issues/1778

Defaults to the value of `sourceMaps` (i.e. `true | false`) if unspecified.

Usage:

```js
{
  test: /\.vue$/,
  loader: 'vue-loader',
  options: {
    pad: true, // boolean | 'line' | 'space'
  },
},
```
