### PR TITLE
fix: add __moduleIdentifier for ssr _registeredComponents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export default function loader(
   const {
     mode,
     target,
+    request,
     sourceMap,
     rootContext,
     resourcePath,
@@ -239,6 +240,9 @@ export default function loader(
     // For security reasons, only expose the file's basename in production.
     code += `\nscript.__file = ${JSON.stringify(path.basename(resourcePath))}`
   }
+
+  // set modlue indentifier for SSR async components preload
+  code += `\nscript.__moduleIdentifier =${JSON.stringify(hash(request))}`
 
   // custom blocks
   if (descriptor.customBlocks && descriptor.customBlocks.length) {


### PR DESCRIPTION
hi, is there any solution for SSR preload async components? maybe I didn't find it, and i find an crude method like this ,
 ```
       const { __moduleIdentifier } = this.$options;
      if (__moduleIdentifier) {
        const ctx = useSSRContext();
        ctx._registeredComponents.add(__moduleIdentifier);
      }
 ```
 but this need add a moduleIdentifier, is there any suggestions and plans?