### PR TITLE
fix: Don't use rules that also match ".html"

### DIFF
--- a/lib/plugin-webpack4.js
+++ b/lib/plugin-webpack4.js
@@ -31,7 +31,12 @@ class VueLoaderPlugin {
     // find the rule that applies to vue files
     let vueRuleIndex = rawRules.findIndex(createMatcher(`foo.vue`))
     if (vueRuleIndex < 0) {
-      vueRuleIndex = rawRules.findIndex(createMatcher(`foo.vue.html`))
+      const vueHtmlRuleIndex = rawRules.findIndex(createMatcher(`foo.vue.html`))
+      const htmlOnlyRuleIndex = rawRules.findIndex(createMatcher(`foo.html`))
+      // Only use the .vue.html rules if they don't also match normal .html files
+      if (vueHtmlRuleIndex >= 0 && htmlOnlyRuleIndex < 0) {
+        vueRuleIndex = vueHtmlRuleIndex
+      }
     }
     const vueRule = rules[vueRuleIndex]
 

--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -60,9 +60,16 @@ class VueLoaderPlugin {
       })
 
       if (!vueRules.length) {
-        vueRules = ruleSet.exec({
+        const vueHtmlRules = ruleSet.exec({
           resource: 'foo.vue.html'
         })
+        const htmlOnlyRules = ruleSet.exec({
+          resource: 'foo.html'
+        })
+        // Only use the .vue.html rules if they don't also match normal .html files
+        if (vueHtmlRules.length > htmlOnlyRules.length) {
+          vueRules = vueHtmlRules
+        }
       }
       if (vueRules.length > 0) {
         if (rawRule.oneOf) {


### PR DESCRIPTION
This adds a check so that rules that match foo.vue.html but also foo.html are ignored.

Resolves #1625

All tests pass and I've verified this myself with Webpack 5. I also added a Webpack 4 version but didn't verify that one.

I don't totally know if my assumption that a vue-loader rule should only match "foo.vue.html" and not "foo.vue" is correct...
Where is "foo.vue.html" used? I only ever use "foo.vue" myself.