### PR TITLE
minimal instructions to vue 3 adopters who use webpack

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -20,6 +20,10 @@ The reason `vue-template-compiler` has to be installed separately is so that you
 
 Every time a new version of `vue` is released, a corresponding version of `vue-template-compiler` is released together. The compiler's version must be in sync with the base `vue` package so that `vue-loader` produces code that is compatible with the runtime. This means **every time you upgrade `vue` in your project, you should upgrade `vue-template-compiler` to match it as well.**
 
+::: warning
+If you are using Vue 3 with Webpack, the installation setup will change to `npm i -D vue-loader@next @vue/compiler-sfc`. You can find more detailed instructions [here](https://stackoverflow.com/questions/64868632/vuejs-3-problem-with-vue-template-compiler).
+:::
+
 ### webpack Configuration
 
 Vue Loader's configuration is a bit different from other loaders. In addition to a rule that applies `vue-loader` to any files with extension `.vue`, make sure to add Vue Loader's plugin to your webpack config:


### PR DESCRIPTION
Problem:
Since vue-template-compiler has no corresponding version to Vue 3, adopters who use Webpack can be confused by this text: "The reason vue-template-compiler has to be installed separately is so that you can individually specify its version. Every time a new version of vue is released, a corresponding version of vue-template-compiler is released together." 

Proposal:
This change suggests a small text to alert these users that they have to change the package and link to a more detailed instruction.