### PR TITLE
Default lang options

### DIFF
--- a/lib/codegen/styleInjection.js
+++ b/lib/codegen/styleInjection.js
@@ -9,7 +9,8 @@ module.exports = function genStyleInjectionCode (
   resourcePath,
   stringifyRequest,
   needsHotReload,
-  needsExplicitInjection
+  needsExplicitInjection,
+  defaultStyleLang,
 ) {
   let styleImportsCode = ``
   let styleInjectionCode = ``
@@ -20,7 +21,7 @@ module.exports = function genStyleInjectionCode (
 
   function genStyleRequest (style, i) {
     const src = style.src || resourcePath
-    const attrsQuery = attrsToQuery(style.attrs, 'css')
+    const attrsQuery = attrsToQuery(style.attrs, defaultStyleLang || 'css')
     const inheritQuery = `&${loaderContext.resourceQuery.slice(1)}`
     // make sure to only pass id when necessary so that we don't inject
     // duplicate tags when multiple components import the same css file

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,7 +124,7 @@ module.exports = function (source) {
   let scriptImport = `var script = {}`
   if (descriptor.script) {
     const src = descriptor.script.src || resourcePath
-    const attrsQuery = attrsToQuery(descriptor.script.attrs, 'js')
+    const attrsQuery = attrsToQuery(descriptor.script.attrs, options.defaultScriptLang || 'js')
     const query = `?vue&type=script${attrsQuery}${inheritQuery}`
     const request = stringifyRequest(src + query)
     scriptImport = (
@@ -143,7 +143,8 @@ module.exports = function (source) {
       resourcePath,
       stringifyRequest,
       needsHotReload,
-      isServer || isShadow // needs explicit injection?
+      isServer || isShadow, // needs explicit injection?
+      options.defaultStyleLang,
     )
   }
 


### PR DESCRIPTION
This adds two new options: `defaultStyleLang` and `defaultScriptLang`.  Personally I always use less and typescript, so I wanted a way to set those as the default.  Example:

    {
      test: /\.vue$/,
      loader: 'vue-loader',
      options: {
        defaultScriptLang: 'ts',
        defaultStyleLang: 'less',
      },
    }