### PR TITLE
fix: pass compilerOptions to compileTemplate when enable inline, fix #1838

### DIFF
--- a/src/resolveScript.ts
+++ b/src/resolveScript.ts
@@ -62,6 +62,7 @@ export function resolveScript(
           compiler,
           ssr: isServer,
           transformAssetUrls: options.transformAssetUrls || true,
+          compilerOptions: options.compilerOptions
         },
       })
     } catch (e) {


### PR DESCRIPTION
## What problem does this PR solve?

when using `<script setup>`:

`vue-loader: resolveScript` -> `compiler-sfc: compileScript` -> `compiler-sfc: compileTemplate`.

`compileTemplate` should receive and merge `options.templateOptions.compilerOptions` which `resolveScript` had not pass in `templateOptions`.

## What had this PR do?

pass `templateOptions.compilerOptions` to `compileScript` in `resolveScript`.fix #1838 .