### PR TITLE
fix: add undeclared peer dependency `webpack` and `@vue/compiler-sfc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     "hash-sum": "^2.0.0",
     "loader-utils": "^2.0.0"
   },
+  "peerDependencies": {
+    "@vue/compiler-sfc": "^3.0.8",
+    "webpack": "^4.1.0 || ^5.0.0-0"
+  },
   "devDependencies": {
     "@babel/core": "^7.7.7",
     "@babel/preset-env": "^7.11.5",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`vue-loader@16` depends on `webpack` and `@vue/compiler-sfc` but doesn't declare it

Fixes https://github.com/vuejs/vue-loader/issues/1844

**How did you fix it?**

Added `webpack` and `@vue/compiler-sfc` as peer dependencies