### PR TITLE
fix invalid sem version in peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "css-loader": "*",
-    "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0-0"
+    "webpack": "^3.0.0 || ^4.1.0 || ^5.0.0"
   },
   "peerDependenciesMeta": {
     "cache-loader": {


### PR DESCRIPTION
Hi,

yarn (v1.22) is complaining that - webpack is not installed

```
warning " > vue-loader@15.9.8" has unmet peer dependency "webpack@^3.0.0 || ^4.1.0 || ^5.0.0-0"
```

Looks like `5.0.0-0` was added when webpack 5 was in early stage.
https://github.com/vuejs/vue-loader/pull/1469
