### PR TITLE
fix ::v-deep bug.

### DIFF
--- a/lib/style-compiler/plugins/scope-id.js
+++ b/lib/style-compiler/plugins/scope-id.js
@@ -27,6 +27,11 @@ module.exports = postcss.plugin('add-id', ({ id }) => root => {
             n.spaces.before = n.spaces.after = ''
             return false
           }
+          //::v-deep pseudo
+          if (n.type === 'pseudo' && n.value === '::v-deep') {
+            n.value = n.spaces.before = n.spaces.after = ''
+            return false
+          }
           // /deep/ alias for >>>, since >>> doesn't work in SASS
           if (n.type === 'tag' && n.value === '/deep/') {
             const prev = n.prev()


### PR DESCRIPTION
add code to solve v14 deep selector bug. v14 is used for many old projects, so..
          //::v-deep pseudo
          if (n.type === 'pseudo' && n.value === '::v-deep') {
            n.value = n.spaces.before = n.spaces.after = ''
            return false
          }
