### PR TITLE
fix(plugin): use compiler.webpack when possible

### DIFF
--- a/src/pluginWebpack5.ts
+++ b/src/pluginWebpack5.ts
@@ -98,14 +98,16 @@ class VueLoaderPlugin implements Plugin {
   static NS = NS
 
   apply(compiler: Compiler) {
+    // @ts-ignore
+    const normalModule = compiler.webpack.NormalModule || NormalModule
+
     // add NS marker so that the loader can detect and report missing plugin
     compiler.hooks.compilation.tap(id, (compilation) => {
-      NormalModule.getCompilationHooks(compilation).loader.tap(
-        id,
-        (loaderContext: any) => {
+      normalModule
+        .getCompilationHooks(compilation)
+        .loader.tap(id, (loaderContext: any) => {
           loaderContext[NS] = true
-        }
-      )
+        })
     })
 
     const rules = compiler.options.module!.rules


### PR DESCRIPTION
Applies the fix (f7ee30b1d0d2398b78cac521000d9710d7972cad) that resolved the same issue on v15.

I had to use `ts-ignore` because the branch uses `webpack@4` types.

Related to #1781