### PR TITLE
Continue looking for vue rule if not the first rule encountered

### DIFF
--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -85,7 +85,7 @@ class VueLoaderPlugin {
           )
         }
         rawVueRules = rawRule
-        break
+        continue
       }
     }
     if (!vueRules.length) {


### PR DESCRIPTION
I believe "continue" was intended here instead of "break".  Unless there is a good reason the vue rule should be the first non-enforce rule.

https://githubmemory.com/repo/vuejs/vue-loader/issues/1826