### PR TITLE
fix: HMR not working correctly with vue-class-component components

### DIFF
--- a/src/exportHelper.ts
+++ b/src/exportHelper.ts
@@ -1,8 +1,9 @@
 // runtime helper for setting properties on components
 // in a tree-shakable way
 export default (sfc: any, props: [string, string][]) => {
+  const target = sfc.__vccOpts || sfc
   for (const [key, val] of props) {
-    sfc[key] = val
+    target[key] = val
   }
-  return sfc
+  return target
 }


### PR DESCRIPTION
vue-loader not registering "__hmrId" on the correct component property
when component is created with vue-class-component.

This leads to vue/compiler-sfc/runtime-core/src/render.ts mountComponent()
function to not call registerHMR() on the instance (because __hmrId is not
attached properly):

```js
  if (__DEV__ && instance.type.__hmrId) {
    registerHMR(instance)
  }
```

Not registering for HMR means the createRecord() map will never get injected
any component instances, so when module.hot.accept() + api.rerender(id, render)
are called they will not apply any update due to finding no instances:

```js
  module.hot.accept("./Index.vue?vue&type=template&id=4bc9d7de&ts=true", () => {
    console.log('re-render')
    api.rerender('4bc9d7de', render) // will never do anything; instances === []
  })
```

This commit fixes the exportComponent from src/exportHelper.ts by injecting the
properties (__file and later down the road __hmrId) to the correct component prop:

```js
  import exportComponent from ".......-loader/dist/exportHelper.js"
  const __exports__ = /*#__PURE__*/exportComponent(script, [['render',render],['__file',"src/pages/Index.vue"]])

  // ...
  /* hot reload */
  if (module.hot) {
    __exports__.__hmrId = "4bc9d7de" // we now have the correct __exports__
```

`script` reference should actually be script.__vccOpts for vue-class-component components,
which is what this commit fixes.