### PR TITLE
refactor: use refTransform instead of deprecated refSugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## v16 Only Options
 
-- `refSugar: boolean`: enable experimental ref sugar.
+- `refTransform: boolean`: enable experimental ref transform.
 
 - `customElement: boolean | RegExp`: enable custom elements mode. An SFC loaded in custom elements mode inlines its `<style>` tags as strings under the component's `styles` option. When used with `defineCustomElement` from Vue core, the styles will be injected into the custom element's shadow root.
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = (env = {}) => {
             test: /\.vue$/,
             loader: 'vue-loader',
             options: {
-              refSugar: true,
+              refTransform: true,
               // enableTsInTemplate: false,
             },
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export interface VueLoaderOptions {
   transformAssetUrls?: SFCTemplateCompileOptions['transformAssetUrls']
   compiler?: TemplateCompiler | string
   compilerOptions?: CompilerOptions
+  refTransform?: boolean
+  /**
+   * @deprecated use `refTransform` instead.
+   */
   refSugar?: boolean
   customElement?: boolean | RegExp
 

--- a/src/resolveScript.ts
+++ b/src/resolveScript.ts
@@ -59,7 +59,7 @@ export function resolveScript(
         id: scopeId,
         isProd,
         inlineTemplate: enableInline,
-        refSugar: options.refSugar,
+        refTransform: options.refSugar || options.refTransform,
         babelParserPlugins: options.babelParserPlugins,
         templateOptions: {
           ssr: isServer,


### PR DESCRIPTION
Since https://github.com/vuejs/vue-next/commit/0805abe573de1ac726a0600077951ff3885653e6 the `refSugar` option has been deprecated,
and replaced with a `refTransform` option.