### PR TITLE
fix: merge custom queries rather than appending

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,11 +75,12 @@ export default function loader(
     sourceMap,
     rootContext,
     resourcePath,
-    resourceQuery = '',
+    resourceQuery: _resourceQuery = '',
   } = loaderContext
 
-  const rawQuery = resourceQuery.slice(1)
+  const rawQuery = _resourceQuery.slice(1)
   const incomingQuery = qs.parse(rawQuery)
+  const resourceQuery = rawQuery ? `&${rawQuery}` : ''
   const options = (loaderUtils.getOptions(loaderContext) ||
     {}) as VueLoaderOptions
 

--- a/test/fixtures/custom-query.vue
+++ b/test/fixtures/custom-query.vue
@@ -1,0 +1,5 @@
+<script lang="ts">
+import BasicComponent from './basic.vue?custom=true'
+
+export default BasicComponent
+</script>

--- a/test/script.spec.ts
+++ b/test/script.spec.ts
@@ -11,3 +11,11 @@ test('named exports', async () => {
 test('experimental <script setup>', async () => {
   await mockBundleAndRun({ entry: 'ScriptSetup.vue' })
 })
+
+test('should handle custom resource query', async () => {
+  const { exports } = await mockBundleAndRun({
+    entry: 'custom-query.vue',
+  })
+
+  expect(exports.default.data().msg).toBe('Hello from Component A!')
+})


### PR DESCRIPTION
Currently we simply append any existing `resourceQuery` to the end of any generated query string. In the event of a custom query being passed this leads to an invalid query, such as:

```js
const scriptQuery = '?vue&type=script&lang=js?custom=true'
const templateQuery = '?vue&type=template&id=49803768?custom=true'
const styleQuery = '?vue&type=style&index=0&id=49803768&lang=css?custom=true'
```

The four locations where this happens are:

https://github.com/vuejs/vue-loader/blob/6dce21e555c28a47f19a13bbe9fa4fa86b2dfc69/src/index.ts#L159
https://github.com/vuejs/vue-loader/blob/6dce21e555c28a47f19a13bbe9fa4fa86b2dfc69/src/index.ts#L179
https://github.com/vuejs/vue-loader/blob/6dce21e555c28a47f19a13bbe9fa4fa86b2dfc69/src/index.ts#L199
https://github.com/vuejs/vue-loader/blob/6dce21e555c28a47f19a13bbe9fa4fa86b2dfc69/src/index.ts#L271

I realise this is a bit of an edge case, but as long as we are appending `resourceQuery` to the end of a query string we should probably normalise it.