### PR TITLE
add vue 3.2.13+ as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "loader-utils": "^2.0.0"
   },
   "peerDependencies": {
-    "webpack": "^4.1.0 || ^5.0.0-0"
+    "webpack": "^4.1.0 || ^5.0.0-0",
+    "vue": "^3.2.13"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",


### PR DESCRIPTION
  Hi @yyx990803 , I find that [vue/compiler-sfc](https://github.com/vuejs/core/tree/main/packages/compiler-sfc) was required explicitly in vue-loader 17+ in [line](https://github.com/vuejs/vue-loader/blob/6a293dff5f2ed3167eb3b448f1d714091185a44e/src/index.ts#L8), but when I install vue-loader separately, it did not give me note that vue 3.2.13+ was required (cuz after vue 3.2.13+, @vue/compiler-sfc was installed with it, so compiler-sfc module can be imported with name **vue/compiler-sfc**). 
  So I make this pr, hope that others won't get same problem.