### PR TITLE
chore: Correct error message

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -18,7 +18,7 @@ try {
     compiler = require('@vue/compiler-sfc')
   } catch (e) {
     throw new Error(
-      `@vitejs/plugin-vue requires vue (>=3.2.13) or @vue/compiler-sfc ` +
+      `vue-loader requires vue (>=3.2.13) or @vue/compiler-sfc ` +
         `to be present in the dependency tree.`
     )
   }


### PR DESCRIPTION
## About

The error message that describes missing compiler was updated in 21725a4ebc9c8d7f8a590d700017759327e21c2e, however, this message is not appropriate for vue-loader. (Perhaps this message is ported from Vite project)