### PR TITLE
fix: webpack5 externalsType.script add vue.js

### DIFF
--- a/lib/codegen/hotReload.js
+++ b/lib/codegen/hotReload.js
@@ -15,17 +15,19 @@ exports.genHotReloadCode = (id, functional, templateRequest) => {
   return `
 /* hot reload */
 if (module.hot) {
-  var api = require(${hotReloadAPIPath})
-  api.install(require('vue'))
-  if (api.compatible) {
-    module.hot.accept()
-    if (!api.isRecorded('${id}')) {
-      api.createRecord('${id}', component.options)
-    } else {
-      api.${functional ? 'rerender' : 'reload'}('${id}', component.options)
+  var api = require(${hotReloadAPIPath});
+  (async () => {
+    api.install(await require('vue'))
+    if (api.compatible) {
+      module.hot.accept()
+      if (!api.isRecorded('${id}')) {
+        api.createRecord('${id}', component.options)
+      } else {
+        api.${functional ? 'rerender' : 'reload'}('${id}', component.options)
+      }
+      ${templateRequest ? genTemplateHotReloadCode(id, templateRequest) : ''}
     }
-    ${templateRequest ? genTemplateHotReloadCode(id, templateRequest) : ''}
-  }
+  })();
 }
   `.trim()
 }


### PR DESCRIPTION
fix webpack dev runtime on use externalsType.script;

review bug: 
webpack config this:
```
externalsType: 'script',
externals: {
  vue: ['https://cdn.jsdelivr.net/npm/vue@2.7.10/dist/vue.js', 'Vue'],
},
```
then, this has error in console
`TypeError: Cannot read properties of undefined (reading 'split')`
and can not render vue anymore.
