### PR TITLE
vue文件id 算法修改 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -243,7 +243,7 @@ export default function loader(
     // from the devtools.
     propsToAttach.push([
       `__file`,
-      JSON.stringify(rawShortFilePath.replace(/\\/g, '/')),
+      JSON.stringify(shortFilePath),
     ])
   } else if (options.exposeFilename) {
     // Libraries can opt-in to expose their components' filenames in production builds.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@ import * as path from 'path'
 import * as qs from 'querystring'
 import * as loaderUtils from 'loader-utils'
 
-import hash = require('hash-sum')
-
 import { parse } from 'vue/compiler-sfc'
 import type {
   TemplateCompiler,
@@ -42,6 +40,7 @@ export interface VueLoaderOptions {
 }
 
 let errorEmitted = false
+let shortFilePathCache: Array<string> = []
 
 const exportHelperPath = JSON.stringify(require.resolve('./exportHelper'))
 
@@ -113,12 +112,9 @@ export default function loader(
   const rawShortFilePath = path
     .relative(rootContext || process.cwd(), filename)
     .replace(/^(\.\.[\/\\])+/, '')
-  const shortFilePath = rawShortFilePath.replace(/\\/g, '/')
-  const id = hash(
-    isProduction
-      ? shortFilePath + '\n' + source.replace(/\r\n/g, '\n')
-      : shortFilePath
-  )
+  const shortFilePath = rawShortFilePath.replace(/\\/g, '/');
+  shortFilePathCache.includes(shortFilePath) || shortFilePathCache.push(shortFilePath);
+  const id = shortFilePathCache.indexOf(shortFilePath).toString(36);
 
   // if the query has a type field, this is a language block request
   // e.g. foo.vue?type=template&id=xxxxx


### PR DESCRIPTION
1：由于为了实现组件样式的scoped，每个css属性都必须附加上[data-v-xxxxxxxx]这样的属性。这样导致css资源大小会被扩大，感觉目前的hash有点长，不够简洁。
![](https://raw.githubusercontent.com/VICTORYGS/imageStorage/main/vueloader_domhash.png)
![](https://raw.githubusercontent.com/VICTORYGS/imageStorage/main/vueloader_css.png)
2：时间上会有略微的提升。目前的算法，当生产环境时，为了防止碰撞，加上的source，此时hash运算会更加耗时。