### PR TITLE
fix: get unique module-id by the hash resourcePath

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,11 +113,10 @@ export default function loader(
   const rawShortFilePath = path
     .relative(rootContext || process.cwd(), filename)
     .replace(/^(\.\.[\/\\])+/, '')
-  const shortFilePath = rawShortFilePath.replace(/\\/g, '/')
   const id = hash(
     isProduction
-      ? shortFilePath + '\n' + source.replace(/\r\n/g, '\n')
-      : shortFilePath
+      ? resourcePath + '\n' + source.replace(/\r\n/g, '\n')
+      : resourcePath
   )
 
   // if the query has a type field, this is a language block request

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -163,7 +163,7 @@ export function normalizeNewline(input: string): string {
 }
 
 // see the logic at src/index.ts
-// in non-production environment, shortFilePath is used to generate scope id
+// in non-production environment, resourcePath is used to generate scope id
 export function genId(fixtureName: string): string {
   return hash(path.join('test', 'fixtures', fixtureName).replace(/\\/g, '/'))
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -165,7 +165,7 @@ export function normalizeNewline(input: string): string {
 // see the logic at src/index.ts
 // in non-production environment, resourcePath is used to generate scope id
 export function genId(fixtureName: string): string {
-  return hash(path.join('test', 'fixtures', fixtureName).replace(/\\/g, '/'))
+  return hash(path.join(__dirname, 'fixtures', fixtureName).replace(/\\/g, '/'))
 }
 
 export { mfs }


### PR DESCRIPTION
Get unique module-id by the hash resourcePath, This makes it possible for multiple projects to run simultaneously on a single project.

e.g.
A parent project has two components, To prevent the module-id conflict.

> After:

ProjectA/`src/view.vue` => module-id: `f82f3d04`

ProjectB/`src/view.vue` => module-id: `f82f3d04`

> Before:

`ProjectA/src/view.vue` => module-id: `541fde99`

`ProjectB/src/view.vue` => module-id: `35fda838`