### PR TITLE
Fix peer warning for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "loader-utils": "^2.0.0"
   },
   "peerDependencies": {
-    "webpack": "^4.1.0 || ^5.0.0-0"
+    "webpack": "^4.1.0 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",


### PR DESCRIPTION
`pnpm` and `yarn` does not consider webpack version valid

![Screenshot from 2022-10-13 11-06-56](https://user-images.githubusercontent.com/6111524/195511108-b85bfcda-6fef-41e6-9581-ca819f835a65.png)
