### PR TITLE
bump loader-utils@^2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "hash-sum": "^2.0.0",
-    "loader-utils": "^2.0.0"
+    "loader-utils": "^2.0.4"
   },
   "peerDependencies": {
     "webpack": "^4.1.0 || ^5.0.0-0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6246,6 +6246,15 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
+loader-utils@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
 high          │ loader-utils is vulnerable to Regular Expression Denial of   │
│               │ Service (ReDoS) via url variable                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ loader-utils                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ vue-loader                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ vue-loader > loader-utils                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1084992  