### PR TITLE
fix: re-use ident of vue rule for template compiler, fixes #2029

### DIFF
--- a/src/pluginWebpack4.ts
+++ b/src/pluginWebpack4.ts
@@ -72,7 +72,10 @@ class VueLoaderPlugin implements webpack.Plugin {
         const parsed = qs.parse(query.slice(1))
         return parsed.vue != null && parsed.type === 'template'
       },
-      options: vueLoaderOptions,
+      options: {
+        ident: vueLoaderUse.ident,
+        ...vueLoaderOptions,
+      },
     }
 
     // for each rule that matches plain .js/.ts files, also create a clone and

--- a/test/edgeCases.spec.ts
+++ b/test/edgeCases.spec.ts
@@ -228,3 +228,30 @@ test('should work with i18n loader in production mode', async () => {
 
   expect(result.componentModule.__i18n).toHaveLength(1)
 })
+
+// #2029
+test('should pass correct options to template compiler', async () => {
+  const fakeCompiler: any = {
+    compile: jest
+      .fn()
+      .mockReturnValue({ code: 'export function render() { return null; }' }),
+  }
+
+  await mockBundleAndRun({
+    entry: 'basic.vue',
+    modify: (config: any) => {
+      config.module.rules[0].options = {
+        compiler: fakeCompiler,
+      }
+      config.module.rules.push(
+        ...Array.from({ length: 10 }).map((_, i) => ({
+          test: new RegExp(`\.dummy${i}`),
+          loader: 'null-loader',
+          options: { dummyRule: i },
+        }))
+      )
+    },
+  })
+
+  expect(fakeCompiler.compile).toHaveBeenCalledTimes(1)
+})


### PR DESCRIPTION
Webpack 4 uses `ident` query param underneath to store `options` objects passed to loaders, and relies on  this `ident` param to retrieve `options` for correct loaders https://github.com/webpack/webpack/blob/v4.46.0/lib/RuleSet.js#L560-L566

Logic of "identing" is pretty straightforward - if `ident` is provided in `options` - that one [is respected](https://github.com/webpack/webpack/blob/v4.46.0/lib/RuleSet.js#L396), but if there is no `ident` - it is [generated](https://github.com/webpack/webpack/blob/v4.46.0/lib/RuleSet.js#L110) based on index of rule in RuleSet

vue-loader [heavily modifies](https://github.com/vuejs/vue-loader/blob/1b1a195612f885a8dec3f371edf1cb8b35d341e4/src/pluginWebpack4.ts#L99-L105) rules **after** `normalizeRules` kicked in and put `ident`'s for existing rules here & there. 

That means that `templateLoader` rule, will receive `ident` based on it's position in `rules` array, but at this point this ident might be **occupied** by some other loader (and that loader will not be "re-indented" because logic there is to maintain existing idents

Since we're putting old rules lower than `templateLoader` - when resoving `ident` --> `options` we will receive wrong object

To fix this we will be reusing `vueLoaderUse` ident. This is 100% safe, since our rule after `identing` will be thrown away so no clash here possible. I was even able to test that :smile: 

This should fix #2029 

   