### PR TITLE
fix: reference project compiler, fixes #2031

### DIFF
--- a/src/descriptorCache.ts
+++ b/src/descriptorCache.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs'
 import type { SFCDescriptor } from 'vue/compiler-sfc'
-import { parse } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
 
+const { parse } = compiler
 const cache = new Map<string, SFCDescriptor>()
 
 export function setDescriptor(filename: string, entry: SFCDescriptor) {

--- a/src/formatError.ts
+++ b/src/formatError.ts
@@ -1,6 +1,8 @@
 import type { CompilerError } from 'vue/compiler-sfc'
-import { generateCodeFrame } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
 import chalk = require('chalk')
+
+const { generateCodeFrame } = compiler
 
 export function formatError(
   err: SyntaxError | CompilerError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import * as loaderUtils from 'loader-utils'
 
 import hash = require('hash-sum')
 
-import { parse } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
 import type {
   TemplateCompiler,
   CompilerOptions,
@@ -43,6 +43,7 @@ export interface VueLoaderOptions {
 
 let errorEmitted = false
 
+const { parse } = compiler
 const exportHelperPath = JSON.stringify(require.resolve('./exportHelper'))
 
 export default function loader(

--- a/src/resolveScript.ts
+++ b/src/resolveScript.ts
@@ -6,8 +6,9 @@ import type {
 } from 'vue/compiler-sfc'
 import type { VueLoaderOptions } from 'src'
 import { resolveTemplateTSOptions } from './util'
-import { compileScript } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
 
+const { compileScript } = compiler
 const clientCache = new WeakMap<SFCDescriptor, SFCScriptBlock | null>()
 const serverCache = new WeakMap<SFCDescriptor, SFCScriptBlock | null>()
 

--- a/src/stylePostLoader.ts
+++ b/src/stylePostLoader.ts
@@ -1,6 +1,8 @@
 import * as qs from 'querystring'
 import webpack = require('webpack')
-import { compileStyle } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
+
+const { compileStyle } = compiler
 
 // This is a post loader that handles scoped CSS transforms.
 // Injected right before css-loader by the global pitcher (../pitch.js)

--- a/src/templateLoader.ts
+++ b/src/templateLoader.ts
@@ -7,7 +7,9 @@ import type { TemplateCompiler } from 'vue/compiler-sfc'
 import { getDescriptor } from './descriptorCache'
 import { resolveScript } from './resolveScript'
 import { resolveTemplateTSOptions } from './util'
-import { compileTemplate } from 'vue/compiler-sfc'
+import { compiler } from './compiler'
+
+const { compileTemplate } = compiler
 
 // Loader that compiles raw template into JavaScript functions.
 // This is injected by the global pitcher (../pitch) for template


### PR DESCRIPTION
This PR fixes this issue #2031. These changes are important in situations where one is only interested in using the loader to compiler the SFCs but not dependent on Vue itself (custom renderer projects).  