### PR TITLE
feat: support experimental inline match resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,15 @@ jobs:
           cache: 'yarn'
       - run: yarn install
       - run: yarn test
+
+  test-webpack5-inline-match-resource:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set node version to 16
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn test:match-resource

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 - [Documentation](https://vue-loader.vuejs.org)
 
+## v17.1+ Only Options
+
+- `experimentalInlineMatchResource: boolean`: enable [Inline matchResource](https://webpack.js.org/api/loaders/#inline-matchresource) for rule matching for vue-loader.
+
 ## v16+ Only Options
 
 - `reactivityTransform: boolean`: enable [Vue Reactivity Transform](https://github.com/vuejs/rfcs/discussions/369) (SFCs only).

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
-console.log(`running tests with webpack ${process.env.WEBPACK4 ? '4' : '5'}...`)
+const isWebpack4 = process.env.WEBPACK4
+
+console.log(
+  `running tests with webpack ${isWebpack4 ? '4' : '5'}${
+    !isWebpack4 && process.env.INLINE_MATCH_RESOURCE
+      ? ' with inline match resource enabled'
+      : ''
+  }...`
+)
 
 module.exports = {
   preset: 'ts-jest',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "tsc",
     "pretest": "tsc",
     "test": "jest",
+    "pretest:match-resource": "tsc",
     "test:match-resource": "INLINE_MATCH_RESOURCE=true jest",
     "pretest:webpack4": "tsc",
     "test:webpack4": "WEBPACK4=true jest",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "tsc",
     "pretest": "tsc",
     "test": "jest",
+    "test:match-resource": "INLINE_MATCH_RESOURCE=true jest",
     "pretest:webpack4": "tsc",
     "test:webpack4": "WEBPACK4=true jest",
     "dev-example": "node example/devServer.js --config example/webpack.config.js --inline --hot",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,19 +1,26 @@
-import webpack from 'webpack'
 import type { Compiler } from 'webpack'
+import { testWebpack5 } from './util'
 
 declare class VueLoaderPlugin {
   static NS: string
   apply(compiler: Compiler): void
 }
 
-let Plugin: typeof VueLoaderPlugin
+const NS = 'vue-loader'
 
-if (webpack.version && webpack.version[0] > '4') {
-  // webpack5 and upper
-  Plugin = require('./pluginWebpack5').default
-} else {
-  // webpack4 and lower
-  Plugin = require('./pluginWebpack4').default
+class Plugin {
+  static NS = NS
+  apply(compiler: Compiler) {
+    let Ctor: typeof VueLoaderPlugin
+    if (testWebpack5(compiler)) {
+      // webpack5 and upper
+      Ctor = require('./pluginWebpack5').default
+    } else {
+      // webpack4 and lower
+      Ctor = require('./pluginWebpack4').default
+    }
+    new Ctor().apply(compiler)
+  }
 }
 
 export default Plugin

--- a/src/util.ts
+++ b/src/util.ts
@@ -169,13 +169,11 @@ export function genMatchResource(
   context: LoaderContext<VueLoaderOptions>,
   resourcePath: string,
   resourceQuery?: string,
-  lang?: string,
-  additionalLoaders?: string[]
+  lang?: string
 ) {
   resourceQuery = resourceQuery || ''
-  additionalLoaders = additionalLoaders || []
 
-  const loaders = [...additionalLoaders]
+  const loaders: string[] = []
   const parsedQuery = qs.parse(resourceQuery.slice(1))
 
   // process non-external resources

--- a/test/advanced.spec.ts
+++ b/test/advanced.spec.ts
@@ -1,6 +1,12 @@
 import { SourceMapConsumer } from 'source-map'
 import { fs as mfs } from 'memfs'
-import { bundle, mockBundleAndRun, normalizeNewline, genId } from './utils'
+import {
+  bundle,
+  mockBundleAndRun,
+  normalizeNewline,
+  genId,
+  DEFAULT_VUE_USE,
+} from './utils'
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
@@ -10,7 +16,7 @@ test('support chaining with other loaders', async () => {
     modify: (config) => {
       config!.module!.rules[0] = {
         test: /\.vue$/,
-        use: ['vue-loader', require.resolve('./mock-loaders/js')],
+        use: [DEFAULT_VUE_USE, require.resolve('./mock-loaders/js')],
       }
     },
   })
@@ -24,7 +30,7 @@ test.skip('inherit queries on files', async () => {
     modify: (config) => {
       config!.module!.rules[0] = {
         test: /\.vue$/,
-        use: ['vue-loader', require.resolve('./mock-loaders/query')],
+        use: [DEFAULT_VUE_USE, require.resolve('./mock-loaders/query')],
       }
     },
   })
@@ -92,7 +98,7 @@ test('extract CSS', async () => {
       config.module.rules = [
         {
           test: /\.vue$/,
-          use: 'vue-loader',
+          use: [DEFAULT_VUE_USE],
         },
         {
           test: /\.css$/,
@@ -126,7 +132,7 @@ test('extract CSS with code spliting', async () => {
       config.module.rules = [
         {
           test: /\.vue$/,
-          use: 'vue-loader',
+          use: [DEFAULT_VUE_USE],
         },
         {
           test: /\.css$/,
@@ -153,7 +159,10 @@ test('support rules with oneOf', async () => {
       entry,
       modify: (config: any) => {
         config!.module!.rules = [
-          { test: /\.vue$/, loader: 'vue-loader' },
+          {
+            test: /\.vue$/,
+            use: [DEFAULT_VUE_USE],
+          },
           {
             test: /\.css$/,
             use: 'style-loader',

--- a/test/edgeCases.spec.ts
+++ b/test/edgeCases.spec.ts
@@ -1,6 +1,12 @@
 import * as path from 'path'
 import webpack from 'webpack'
-import { mfs, bundle, mockBundleAndRun, normalizeNewline } from './utils'
+import {
+  mfs,
+  bundle,
+  mockBundleAndRun,
+  normalizeNewline,
+  DEFAULT_VUE_USE,
+} from './utils'
 
 // @ts-ignore
 function assertComponent({
@@ -37,7 +43,7 @@ test('vue rule with include', async () => {
       config.module.rules[i] = {
         test: /\.vue$/,
         include: /fixtures/,
-        loader: 'vue-loader',
+        use: [DEFAULT_VUE_USE],
       }
     },
   })
@@ -52,7 +58,7 @@ test('test-less oneOf rules', async () => {
       config!.module!.rules = [
         {
           test: /\.vue$/,
-          loader: 'vue-loader',
+          use: [DEFAULT_VUE_USE],
         },
         {
           oneOf: [
@@ -79,12 +85,7 @@ test('normalize multiple use + options', async () => {
       )
       config!.module!.rules[i] = {
         test: /\.vue$/,
-        use: [
-          {
-            loader: 'vue-loader',
-            options: {},
-          },
-        ],
+        use: [DEFAULT_VUE_USE],
       }
     },
   })

--- a/test/style.spec.ts
+++ b/test/style.spec.ts
@@ -1,4 +1,9 @@
-import { mockBundleAndRun, genId, normalizeNewline } from './utils'
+import {
+  mockBundleAndRun,
+  genId,
+  normalizeNewline,
+  DEFAULT_VUE_USE,
+} from './utils'
 
 test('scoped style', async () => {
   const { window, instance, componentModule } = await mockBundleAndRun({
@@ -109,7 +114,7 @@ test('CSS Modules', async () => {
         config!.module!.rules = [
           {
             test: /\.vue$/,
-            loader: 'vue-loader',
+            use: [DEFAULT_VUE_USE],
           },
           {
             test: /\.css$/,
@@ -178,7 +183,7 @@ test('CSS Modules Extend', async () => {
       config!.module!.rules = [
         {
           test: /\.vue$/,
-          loader: 'vue-loader',
+          use: [DEFAULT_VUE_USE],
         },
         {
           test: /\.css$/,

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { mockBundleAndRun, normalizeNewline } from './utils'
+import { DEFAULT_VUE_USE, mockBundleAndRun, normalizeNewline } from './utils'
 
 test('apply babel transformations to expressions in template', async () => {
   const { instance } = await mockBundleAndRun({
@@ -111,7 +111,7 @@ test('should allow process custom file', async () => {
       rules: [
         {
           test: /\.svg$/,
-          loader: 'vue-loader',
+          use: [DEFAULT_VUE_USE],
         },
       ],
     },

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,7 +6,8 @@ import hash from 'hash-sum'
 // import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import { fs as mfs } from 'memfs'
 import { JSDOM, VirtualConsole } from 'jsdom'
-import type { VueLoaderOptions, VueLoaderPlugin } from '..'
+import { VueLoaderPlugin } from '..'
+import type { VueLoaderOptions } from '..'
 
 export const DEFAULT_VUE_USE = {
   loader: 'vue-loader',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,13 +14,7 @@
     "noImplicitAny": true,
     "removeComments": false,
     "skipLibCheck": true,
-    "lib": [
-      "es6",
-      "es7",
-      "DOM"
-    ]
+    "lib": ["es6", "es7", "DOM"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
This PR leverages inline match resource, a new technique provided by Webpack@5 
to process modules, which allows loader developers to write more ergonomic code
and make the code easier to maintain. From now on, you can enable 
`options.experimentalInlineMatchResource` of `vue-loader` to give it a try.

Other minor changes: 
1. Dispatch `VueLoaderPlugin` dynamically to decouple webpack and support webpack-like plugin systems.
2. Webpack@5 `experiments.css` support

Note:
The ideal solution with inline match resource is to get rid of the `VueLoaderPlugin` completely, 
I will try to optimize this in the future.


