### PR TITLE
feat: skip normal css files without scoped flag in stylePostLoader

### DIFF
--- a/src/stylePostLoader.ts
+++ b/src/stylePostLoader.ts
@@ -9,6 +9,13 @@ const { compileStyle } = compiler
 // for any <style scoped> selection requests initiated from within vue files.
 const StylePostLoader: LoaderDefinitionFunction = function (source, inMap) {
   const query = qs.parse(this.resourceQuery.slice(1))
+
+  // skip normal CSS files without scoped flag
+  if (!('vue' in query) && !query.scoped) {
+    this.callback(null, source, inMap)
+    return
+  }
+
   const { code, map, errors } = compileStyle({
     source: source as string,
     filename: this.resourcePath,

--- a/src/stylePostLoader.ts
+++ b/src/stylePostLoader.ts
@@ -11,7 +11,12 @@ const StylePostLoader: LoaderDefinitionFunction = function (source, inMap) {
   const query = qs.parse(this.resourceQuery.slice(1))
 
   // skip normal CSS files without scoped flag
-  if (!('vue' in query) && !query.scoped) {
+  if (
+    !('vue' in query) ||
+    query.type !== 'style' ||
+    !query.id ||
+    !query.scoped
+  ) {
     this.callback(null, source, inMap)
     return
   }

--- a/test/core.spec.ts
+++ b/test/core.spec.ts
@@ -75,7 +75,7 @@ test('style import', async () => {
   })
 
   const styles = window.document.querySelectorAll('style')
-  expect(styles[0].textContent).toContain('h1 { color: red;\n}')
+  expect(styles[0].textContent).toContain('h1 { color: red; }')
 
   // import with scoped
   const id = 'data-v-' + genId('style-import.vue')
@@ -89,7 +89,7 @@ test('style import for a same file twice', async () => {
 
   const styles = window.document.querySelectorAll('style')
   expect(styles.length).toBe(3)
-  expect(styles[0].textContent).toContain('h1 { color: red;\n}')
+  expect(styles[0].textContent).toContain('h1 { color: red; }')
 
   // import with scoped
   const id = 'data-v-' + genId('style-import-twice-sub.vue')

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -56,8 +56,8 @@ test('transform relative URLs and respects resolve alias', async () => {
   const style = normalizeNewline(
     window.document.querySelector('style')!.textContent!
   )
-  expect(style).toContain('html { background-image: url(logo.cab72b.png);\n}')
-  expect(style).toContain('body { background-image: url(logo.cab72b.png);\n}')
+  expect(style).toContain('html { background-image: url(logo.cab72b.png); }')
+  expect(style).toContain('body { background-image: url(logo.cab72b.png); }')
 })
 
 test('customizing template loaders', async () => {


### PR DESCRIPTION
So the loader `vue-loader/dist/stylePostLoader.js` can be used for pre-compiled Vue component files to handle scoped style imports.

e.g. in a Vue CLI project, you can just add these lines of code to make it work:

```js
const { defineConfig } = require("@vue/cli-service");

module.exports = defineConfig({
  ...
  chainWebpack: (config) => {
    const ruleNameList = ["css", "scss", "sass", "less", "stylus"];
    ruleNameList.forEach((ruleName) => {
      const rule = config.module.rule(ruleName);
      rule
        .oneOf("normal")
        .use("style-post-loader")
        .loader("vue-loader/dist/stylePostLoader.js");
    });
    return config;
  },
});
```

...which would be great to be put into the default config of Vue CLI, despite it being out of maintenance.

Similar feature PR to Vite Plugin Vue: https://github.com/vitejs/vite-plugin-vue/pull/196