### PR TITLE
chore: refactor hash()

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "hash-sum": "^2.0.0",
     "watchpack": "^2.4.0"
   },
   "peerDependencies": {
@@ -56,7 +55,6 @@
     "@babel/preset-env": "^7.11.5",
     "@intlify/vue-i18n-loader": "^3.0.0",
     "@types/estree": "^0.0.45",
-    "@types/hash-sum": "^1.0.0",
     "@types/jest": "^26.0.13",
     "@types/jsdom": "^16.2.13",
     "@types/mini-css-extract-plugin": "^0.9.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import type { LoaderContext } from 'webpack'
 import * as path from 'path'
+import * as crypto from 'crypto'
 import * as qs from 'querystring'
-
-import hash = require('hash-sum')
 
 import { compiler } from './compiler'
 import type {
@@ -65,6 +64,10 @@ let errorEmitted = false
 
 const { parse } = compiler
 const exportHelperPath = require.resolve('./exportHelper')
+
+function hash(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex').substring(0, 8)
+}
 
 export default function loader(
   this: LoaderContext<VueLoaderOptions>,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,13 +1,17 @@
 /* env jest */
 import * as path from 'path'
+import * as crypto from 'crypto'
 import webpack from 'webpack'
 import merge from 'webpack-merge'
-import hash from 'hash-sum'
 // import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 import { fs as mfs } from 'memfs'
 import { JSDOM, VirtualConsole } from 'jsdom'
 import { VueLoaderPlugin } from '..'
 import type { VueLoaderOptions } from '..'
+
+function hash(text: string): string {
+  return crypto.createHash('sha256').update(text).digest('hex').substring(0, 8)
+}
 
 export const DEFAULT_VUE_USE = {
   loader: 'vue-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1317,11 +1317,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hash-sum@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/hash-sum/-/hash-sum-1.0.0.tgz#838f4e8627887d42b162d05f3d96ca636c2bc504"
-  integrity sha512-FdLBT93h3kcZ586Aee66HPCVJ6qvxVjBlDWNmxSGSbCZe9hTsjRKdSsl4y1T+3zfujxo9auykQMnFsfyHWD7wg==
-
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -4924,11 +4919,6 @@ hash-base@^3.0.0:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
-
-hash-sum@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
-  integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"


### PR DESCRIPTION
Replace `hash-sum` with the same algorithm that `@vite/plugin-vue` does for scoped id.

~~Note: there are 2 test cases failed which need a further look.~~

Thanks.