### PR TITLE
fix: add tests for SSR render

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "packageManager": "pnpm@8.12.0",
   "dependencies": {
     "chalk": "^4.1.0",
+    "hash-sum": "^2.0.0",
     "watchpack": "^2.4.0"
   },
   "peerDependencies": {
@@ -57,6 +58,7 @@
     "@intlify/vue-i18n-loader": "^3.0.0",
     "@types/cssesc": "^3.0.2",
     "@types/estree": "^0.0.45",
+    "@types/hash-sum": "^1.0.2",
     "@types/jest": "^26.0.13",
     "@types/jsdom": "^16.2.13",
     "@types/mini-css-extract-plugin": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "packageManager": "pnpm@8.12.0",
   "dependencies": {
     "chalk": "^4.1.0",
-    "hash-sum": "^2.0.0",
     "watchpack": "^2.4.0"
   },
   "peerDependencies": {
@@ -58,7 +57,6 @@
     "@intlify/vue-i18n-loader": "^3.0.0",
     "@types/cssesc": "^3.0.2",
     "@types/estree": "^0.0.45",
-    "@types/hash-sum": "^1.0.2",
     "@types/jest": "^26.0.13",
     "@types/jsdom": "^16.2.13",
     "@types/mini-css-extract-plugin": "^0.9.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,6 @@ import type {
   SFCScriptCompileOptions,
 } from 'vue/compiler-sfc'
 
-import hashSum from 'hash-sum'
-
 import { selectBlock } from './select'
 import { genHotReloadCode } from './hotReload'
 import { genCSSModulesCode } from './cssModules'
@@ -372,7 +370,7 @@ export default function loader(
     ;(code += `script.setup = (props, ctx) => {`),
       (code += `  const ssrContext = useSSRContext()`),
       (code += `  ;(ssrContext._registeredComponents || (ssrContext._registeredComponents = new Set())).add(${JSON.stringify(
-        hashSum(loaderContext.request)
+        hash(loaderContext.request)
       )});`)
     code += `  return _setup ? _setup(props, ctx) : undefined`
     code += `}\n`

--- a/test/fixtures/functional-style.vue
+++ b/test/fixtures/functional-style.vue
@@ -1,0 +1,13 @@
+<script>
+import {h} from 'vue';
+export default {
+  functional: true,
+  render () {
+    return h('div', { class: 'foo' }, ['functional'])
+  }
+}
+</script>
+
+<style>
+.foo { color: red; }
+</style>

--- a/test/fixtures/ssr-entry.js
+++ b/test/fixtures/ssr-entry.js
@@ -1,0 +1,17 @@
+import { renderToString } from 'vue/server-renderer'
+import { createSSRApp } from 'vue'
+
+import Component from '~target'
+import * as exports from '~target'
+
+export async function main() {
+  const instance = createSSRApp(Component)
+  const ssrContext = {}
+  const markup = await renderToString(instance, ssrContext)
+  return {
+    instance,
+    markup,
+    componentModule: Component,
+    ssrContext,
+  }
+}

--- a/test/fixtures/ssr-style.vue
+++ b/test/fixtures/ssr-style.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h1>Hello</h1>
+    <basic/>
+    <functional-style/>
+  </div>
+</template>
+
+<script>
+import Basic from './basic.vue'
+import FunctionalStyle from './functional-style.vue'
+
+export default {
+  components: {
+    Basic,
+    FunctionalStyle
+  }
+}
+</script>
+
+<style>
+h1 { color: green; }
+</style>
+
+<style src="./style-import.css"></style>

--- a/test/ssr.spec.ts
+++ b/test/ssr.spec.ts
@@ -1,0 +1,79 @@
+import { mockServerBundleAndRun, genId, DEFAULT_VUE_USE } from './utils'
+
+test('SSR style and moduleId extraction', async () => {
+  const { markup, ssrContext } = await mockServerBundleAndRun({
+    entry: 'ssr-style.vue',
+  })
+
+  expect(markup).toContain('<h1>Hello</h1>')
+  expect(markup).toContain('Hello from Component A!')
+  expect(markup).toContain('<div class="foo">functional</div>')
+  // collect component identifiers during render
+  expect(Array.from(ssrContext._registeredComponents).length).toBe(3)
+})
+
+test('SSR with scoped CSS', async () => {
+  const { markup } = await mockServerBundleAndRun({
+    entry: 'scoped-css.vue',
+  })
+
+  const shortId = genId('scoped-css.vue')
+  const id = `data-v-${shortId}`
+
+  expect(markup).toContain(`<div ${id}>`)
+  expect(markup).toContain(`<svg ${id}>`)
+})
+
+test('SSR + CSS Modules', async () => {
+  const testWithIdent = async (
+    localIdentName: string | undefined,
+    regexToMatch: RegExp
+  ) => {
+    const baseLoaders = [
+      'style-loader',
+      {
+        loader: 'css-loader',
+        options: {
+          modules: {
+            localIdentName,
+          },
+        },
+      },
+    ]
+
+    const { componentModule } = await mockServerBundleAndRun({
+      entry: 'css-modules.vue',
+      modify: (config: any) => {
+        config!.module!.rules = [
+          {
+            test: /\.vue$/,
+            use: [DEFAULT_VUE_USE],
+          },
+          {
+            test: /\.css$/,
+            use: baseLoaders,
+          },
+          {
+            test: /\.stylus$/,
+            use: [...baseLoaders, 'stylus-loader'],
+          },
+        ]
+      },
+    })
+
+    const instance = componentModule.__cssModules
+
+    // get local class name
+    const className = instance!.$style.red
+    expect(className).toMatch(regexToMatch)
+  }
+
+  // default ident
+  await testWithIdent(undefined, /^\w{21,}/)
+
+  // custom ident
+  await testWithIdent(
+    '[path][name]---[local]---[hash:base64:5]',
+    /css-modules---red---\w{5}/
+  )
+})


### PR DESCRIPTION
This PR continues on the work of https://github.com/vuejs/vue-loader/pull/2079 by adding missing tests removed in https://github.com/vuejs/vue-loader/commit/20352da36bf5e37b761ab48971f25f194e6dac7c and [based on implementation at v15 version of loader](https://github.com/vuejs/vue-loader/blob/master/test/ssr.spec.js).

SSR context styles are not present since I couldn’t get final result inside context. As I see it, that currently isn’t possible since all the CSS is automatically extracted, but maybe it could be achivede with additional loader after all the CSS has been preprocessed?

v15 version relies on vue-style-loader so I think that’s why it was possible to get all the necessary information.

Also, hashing function from original PR has been moved from `hash-sum` to internal one to align with Vite and other hashing behavior. It’s possible that this could clash with [Nuxt Vue client manifest package implementation](https://github.com/nuxt/nuxt/blob/main/packages/webpack/src/plugins/vue/client.ts).

@sodatea Is it possible we can get this implemented? This would greatly help with collecting all the necessary components needed for initial render in SSR contexts. After that, maybe we could work on critical CSS implementation.